### PR TITLE
fix(inject-destroy): add onDestroy to return value of injectDestroy

### DIFF
--- a/docs/src/content/docs/utilities/inject-destroy.md
+++ b/docs/src/content/docs/utilities/inject-destroy.md
@@ -52,6 +52,29 @@ export class MyComponent {
 
 As you can see, we don't need to implement `OnDestroy` anymore and we don't need to manually emit from the `Subject` when the component is destroyed.
 
+### `onDestroy`
+
+The value returned by `injectDestroy()` also includes `onDestroy()` function to register arbitrary destroy logic callbacks.
+
+```ts
+
+@Component({})
+export class MyComponent {
+  private dataService = inject(DataService);
+  private destroy$ = injectDestroy();
+
+  ngOnInit() {
+    this.dataService.getData()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(...);
+
+    this.destroy$.onDestroy(() => {
+      /* other destroy logics, similar to DestroyRef#onDestroy */
+    });
+  }
+}
+```
+
 ## How it works
 
 The helper functions injects the `DestroyRef` class from Angular, and on the `onDestroy` lifecycle hook, it emits from the `Subject` and completes it.

--- a/libs/ngxtension/inject-destroy/src/inject-destroy.ts
+++ b/libs/ngxtension/inject-destroy/src/inject-destroy.ts
@@ -1,8 +1,8 @@
 import {
 	DestroyRef,
 	inject,
-	Injector,
 	runInInjectionContext,
+	type Injector,
 } from '@angular/core';
 import { assertInjector } from 'ngxtension/assert-injector';
 import { ReplaySubject } from 'rxjs';
@@ -26,7 +26,9 @@ import { ReplaySubject } from 'rxjs';
  *   }
  * }
  */
-export const injectDestroy = (injector?: Injector) => {
+export const injectDestroy = (
+	injector?: Injector
+): ReplaySubject<void> & { onDestroy: DestroyRef['onDestroy'] } => {
 	injector = assertInjector(injectDestroy, injector);
 
 	return runInInjectionContext(injector, () => {
@@ -39,6 +41,12 @@ export const injectDestroy = (injector?: Injector) => {
 			subject$.complete();
 		});
 
-		return subject$;
+		Object.assign(subject$, {
+			onDestroy: destroyRef.onDestroy.bind(destroyRef),
+		});
+
+		return subject$ as ReplaySubject<void> & {
+			onDestroy: DestroyRef['onDestroy'];
+		};
 	});
 };


### PR DESCRIPTION
This PR augments the return type of `injectDestroy` to also include `onDestroy` so that folks don't have to `inject(DestroyRef)` when they need it to run arbitrary destroy logic using `DestroyRef#onDestroy`