### PR TITLE
Additional Intl API helpers

### DIFF
--- a/apps/test-app/src/app/app.component.ts
+++ b/apps/test-app/src/app/app.component.ts
@@ -20,6 +20,10 @@ import { RouterLink, RouterOutlet } from '@angular/router';
 			<li>
 				<a routerLink="/track-by">Track By</a>
 			</li>
+
+			<li>
+				<a routerLink="/intl">Intl</a>
+			</li>
 		</ul>
 
 		<hr />

--- a/apps/test-app/src/app/app.config.ts
+++ b/apps/test-app/src/app/app.config.ts
@@ -16,6 +16,10 @@ export const appConfig: ApplicationConfig = {
 				path: 'track-by',
 				loadComponent: () => import('./track-by/track-by.component'),
 			},
+			{
+				path: 'intl',
+				loadComponent: () => import('./intl/intl.component'),
+			},
 		]),
 	],
 };

--- a/apps/test-app/src/app/intl/intl.component.ts
+++ b/apps/test-app/src/app/intl/intl.component.ts
@@ -1,0 +1,57 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import {
+	DisplayNamesPipe,
+	PluralRulesPipe,
+	RelativeTimeFormatPipe,
+} from 'ngxtension/intl';
+
+@Component({
+	selector: 'ngxtension-platform-intl',
+	standalone: true,
+	imports: [
+		CommonModule,
+		DisplayNamesPipe,
+		PluralRulesPipe,
+		RelativeTimeFormatPipe,
+	],
+	template: `
+		<h2>Plural Rules</h2>
+		<p>
+			<strong ngNonBindable>{{ 1 | pluralRules }}</strong>
+			=> {{ 1 | pluralRules }}
+		</p>
+		<p>
+			<strong ngNonBindable>{{ 2 | pluralRules }}</strong>
+			=> {{ 2 | pluralRules }}
+		</p>
+
+		<h2>Relative Time Format</h2>
+		<p>
+			<strong ngNonBindable>{{ 1 | relativeTimeFormat : 'day' }}</strong>
+			=> {{ 1 | relativeTimeFormat : 'day' }}
+		</p>
+		<p>
+			<strong ngNonBindable>{{ -1 | relativeTimeFormat : 'day' }}</strong>
+			=> {{ -1 | relativeTimeFormat : 'day' }}
+		</p>
+
+		<h2>Display Names</h2>
+		<p>
+			<strong ngNonBindable>{{ 'en' | displayNames : 'language' }}</strong>
+			=> {{ 'en' | displayNames : 'language' }}
+		</p>
+		<p>
+			<strong ngNonBindable>{{ 'en' | displayNames : 'script' }}</strong>
+			=> {{ 'en' | displayNames : 'script' }}
+		</p>
+		<p>
+			<strong ngNonBindable>{{ 'en' | displayNames : 'region' }}</strong>
+			=> {{ 'en' | displayNames : 'region' }}
+		</p>
+	`,
+	host: {
+		style: 'display: block',
+	},
+})
+export default class IntlComponent {}

--- a/docs/src/content/docs/utilities/connect.md
+++ b/docs/src/content/docs/utilities/connect.md
@@ -6,7 +6,7 @@ description: ngxtension/connect
 `connect` is a utility function that connects a signal to an observable and returns a subscription. The subscription is automatically unsubscribed when the component is destroyed. If it's not called in an injection context, it must be called with an injector or DestroyRef.
 
 ```ts
-import { connect } from '@ngxtension/connect';
+import { connect } from 'ngxtension/connect';
 ```
 
 ## Usage

--- a/docs/src/content/docs/utilities/intl.md
+++ b/docs/src/content/docs/utilities/intl.md
@@ -1,0 +1,357 @@
+---
+title: Intl
+description: Additional Intl Utilities for formatting numbers, strings, and other objects.
+---
+
+This is a collection of pipes designed for Angular applications that leverage the [Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+
+While it's not intended to fully replace Angular's standard pipes for `currency`, `date`, and `number`, it serves as a supplemental toolkit to enhance existing functionalities.
+
+The default locale is determined by the [`LOCALE_ID` token](https://angular.io/api/core/LOCALE_ID). Altering this will change the locale for all included pipes.
+
+Alternatively, you can specify the locale directly as the **final parameter to any pipe, thereby overriding the default setting**.
+
+These pipes aim to utilize the Intl API. In cases where the Intl API is unavailable, the pipes will automatically resort to alternative methods, varying by the specific pipe in use.
+
+For instance, [`DisplayNamesPipe`](#displaynamespipe) processes the code value passed into it, whereas [`ListFormatPipe`](#listformatpipe) outputs the array values as a string.
+
+Should an issue arise, an error message will be displayed in the console to provide further insights.
+
+## DisplayNamesPipe
+
+Displays the localized display name of the given key for the given type.
+
+For example, the display name of the language code "en" in English is "English", and in German it's "Englisch".
+
+### Usage
+
+Import `DisplayNamesPipe` and add it to your component:
+
+```ts
+import {Component} from "@angular/core";
+import {DisplayNamesPipe} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [DisplayNamesPipe],
+  template: `
+    <p>{{ 'en' | displayNames: 'language' }}</p>
+  `
+})
+```
+
+If `LOCALE_ID` is set to `en-US`, the above example will display `English`, while if it's set to `de-DE`, it will display `Englisch`.
+
+Additionally, you can **send the style and locale as parameters**:
+
+```html
+<p>{{ 'en' | displayNames: 'language' : 'long' : 'de' }}</p>
+```
+
+The above example will display `Englisch` in German locale, no matter what `LOCALE_ID` is set to.
+
+### Configuration
+
+To explore additional configuration settings, you can customize the `DisplayNamesPipe` by modifying the default options through the `provideDisplayNamesOptions` provider:
+
+```ts
+import {Component} from "@angular/core";
+import {DisplayNamesPipe, provideDisplayNamesOptions} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [DisplayNamesPipe],
+  providers: [
+    provideDisplayNamesOptions({
+      localeMatcher: 'best fit',
+      style: 'long',
+    })
+  ],
+  template: `
+    <p>{{ 'en' | displayNames }}</p>
+  `
+})
+```
+
+The default options are:
+
+```ts
+const defaultOptions: DisplayNamesOptions = {
+	style: 'short',
+	localeMatcher: 'lookup',
+	fallback: 'code',
+};
+```
+
+For more information, check the [DisplayNames API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames).
+
+### Error Handling
+
+If an error occurs, the pipe will return the value that was sent to it, and a console error will be displayed with more details.
+
+`{{ 'any-nonvalid-value' | displayNames: 'language' }}` will return `any-nonvalid-value`.
+
+## ListFormatPipe
+
+Displays the localized string representation of a list of elements.
+
+For example, the list `['en', 'fr', 'de']` will be displayed as `en, fr, and de` in English, and `en, fr et de` in French.
+
+### Usage
+
+Import `ListFormatPipe` and add it to your component:
+
+```ts
+import {Component} from "@angular/core";
+import {ListFormatPipe} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [ListFormatPipe],
+  template: `
+    <p>{{ ['en', 'fr', 'de'] | listFormat }}</p>
+  `
+})
+```
+
+If `LOCALE_ID` is set to `en-US`, the above example will display `en, fr, and de`, while if it's set to `fr-FR`, it will display `en, fr et de`.
+
+Additionally, you can **send the style and locale as parameters**:
+
+```html
+<p>{{ ['en', 'fr', 'de'] | listFormat : 'long' : 'fr' }}</p>
+```
+
+The above example will display `en, fr et de` in French locale, no matter what `LOCALE_ID` is set to.
+
+### Configuration
+
+To explore additional configuration settings, you can customize the `ListFormatPipe` by modifying the default options through the `provideListFormatOptions` provider:
+
+```ts
+import {Component} from "@angular/core";
+import {ListFormatPipe, provideListFormatOptions} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [ListFormatPipe],
+  providers: [
+    provideListFormatOptions({
+      style: 'short',
+      type: 'conjunction',
+    })
+  ],
+  template: `
+    <p>{{ ['en', 'fr', 'de'] | listFormat }}</p>
+  `
+})
+```
+
+The default options are:
+
+```ts
+const defaultOptions: ListFormatOptions = {
+	style: 'long',
+	type: 'conjunction',
+};
+```
+
+For more information, check the [ListFormat API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat).
+
+### Error Handling
+
+If an error occurs, the pipe will return the value of the array as string, and a console error will be displayed with more details.
+
+`{{ ['en', 'fr', 'de'] | listFormat }}` will return `en, fr, de`.
+
+## PluralRulesPipe
+
+Displays the localized string representation of a plural value.
+
+For example, the value `1` will be displayed as `one` in English, and `uno` in Spanish.
+
+### Usage
+
+Import `PluralRulesPipe` and add it to your component:
+
+```ts
+import {Component} from "@angular/core";
+import {PluralRulesPipe} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [PluralRulesPipe],
+  template: `
+    <p>{{ 1 | pluralRules }}</p>
+  `
+})
+```
+
+If `LOCALE_ID` is set to `en-US`, the above example will display `one`, while if it's set to `es-ES`, it will display `uno`.
+
+Additionally, you can **send locale as last parameter**:
+
+```html
+<p>{{ 1 | pluralRules: 'en-US' }}</p>
+```
+
+The above example will display `one` in English locale, no matter what `LOCALE_ID` is set to.
+
+### Configuration
+
+To explore additional configuration settings, you can customize the `PluralRulesPipe` by modifying the default options through the `providePluralRulesOptions` provider:
+
+```ts
+import {Component} from "@angular/core";
+import {PluralRulesPipe, providePluralRulesOptions} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [PluralRulesPipe],
+  providers: [
+    providePluralRulesOptions({
+      type: 'ordinal',
+    })
+  ],
+  template: `
+    <p>{{ 1 | pluralRules }}</p>
+  `
+})
+```
+
+The default options are:
+
+```ts
+const defaultOptions: Intl.PluralRulesOptions = {
+	localeMatcher: 'best fit', // other values: "lookup",
+	type: 'cardinal', // other values: "ordinal"
+};
+```
+
+For more information, check the [PluralRules API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).
+
+### Error Handling
+
+If an error occurs, the pipe will return the value that was sent to it, and a console error will be displayed with more details.
+
+`{{ 1 | pluralRules }}` will return `1`.
+
+## RelativeTimeFormatPipe
+
+Displays the localized string representation of a relative time value.
+
+For example, the value `1` will be displayed as `in 1 day` in English, and `dentro de 1 día` in Spanish.
+
+### Usage
+
+Import `RelativeTimeFormatPipe` and add it to your component:
+
+```ts
+import {Component} from "@angular/core";
+import {RelativeTimeFormatPipe} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RelativeTimeFormatPipe],
+  template: `
+    <p>{{ 1 | relativeTimeFormat: 'day' }}</p>
+  `
+})
+```
+
+If `LOCALE_ID` is set to `en-US`, the above example will display `in 1 day`, while if it's set to `es-ES`, it will display `dentro de 1 día`.
+
+Additionally, you can **send style and locale as parameters**:
+
+```html
+<p>{{ 1 | relativeTimeFormat: 'day' : 'long' : 'es-ES' }}</p>
+```
+
+The above example will display `dentro de 1 día` in Spanish locale, no matter what `LOCALE_ID` is set to.
+
+### Configuration
+
+To explore additional configuration settings, you can customize the `RelativeTimeFormatPipe` by modifying the default options through the `provideRelativeTimeFormatOptions` provider:
+
+```ts
+import {Component} from "@angular/core";
+import {RelativeTimeFormatPipe, provideRelativeTimeFormatOptions} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RelativeTimeFormatPipe],
+  providers: [
+    provideRelativeTimeFormatOptions({
+      numeric: 'auto',
+      style: 'long',
+    })
+  ],
+  template: `
+    <p>{{ 1 | relativeTimeFormat: 'day' }}</p>
+  `
+})
+```
+
+The default options are:
+
+```ts
+const defaultOptions: Intl.RelativeTimeFormatOptions = {
+	localeMatcher: 'best fit', // other values: "lookup",
+	numeric: 'always', // other values: "auto"
+	style: 'long', // other values: "short" or "narrow"
+};
+```
+
+For more information, check the [RelativeTimeFormat API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat).
+
+### Error Handling
+
+If an error occurs, the pipe will return the value that was sent to it, and a console error will be displayed with more details.
+
+`{{ 1 | relativeTimeFormat: 'day' }}` will return `1`.
+
+## SupportedValuesOf
+
+This is a utility transforms a key into an array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
+
+### Usage
+
+Import `SupportedValuesOf` and add it to your component:
+
+```ts
+
+import {Component} from "@angular/core";
+import {SupportedValuesOf} from '@ngxtension/intl';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [SupportedValuesOf],
+  template: `
+    <p>{{ 'currency' | supportedValuesOf }}</p>
+  `
+})
+```
+
+The above example will display `["BRL", "CNY", "EUR", "GBP", "INR", "JPY", "KRW", "MXN", "RUB", "USD"]` if `LOCALE_ID` is set to `en-US`.
+
+The key can be any of the following:
+
+- `calendar` - Supported calendar values, such as `buddhist`, `chinese`, `coptic`, and so on.
+- `collation` - Supported collation values, such as `big5han`, `compat`, `ebase`, `emoji`, and so on.
+- `currency` - Supported currency values, such as `BRL`, `CNY`, `EUR`, and so on.
+- `numberingSystem` - Supported numbering system values, such as `arab`, `arabext`, `bali`, and so on.
+- `timeZone` - Supported time zone values, such as `America/Los_Angeles`, `Asia/Kolkata`, `Asia/Tokyo`, and so on.
+- `unit` - Supported unit values, such as `acre`, `bit`, `byte`, `celsius`, and so on.
+
+Not sure how often you'll need this, but it's there if you do.
+
+For more information, check the [SupportedValuesOf API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf).

--- a/docs/src/content/docs/utilities/intl.md
+++ b/docs/src/content/docs/utilities/intl.md
@@ -29,7 +29,7 @@ Import `DisplayNamesPipe` and add it to your component:
 
 ```ts
 import {Component} from "@angular/core";
-import {DisplayNamesPipe} from '@ngxtension/intl';
+import {DisplayNamesPipe} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -57,7 +57,7 @@ To explore additional configuration settings, you can customize the `DisplayName
 
 ```ts
 import {Component} from "@angular/core";
-import {DisplayNamesPipe, provideDisplayNamesOptions} from '@ngxtension/intl';
+import {DisplayNamesPipe, provideDisplayNamesOptions} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -105,7 +105,7 @@ Import `ListFormatPipe` and add it to your component:
 
 ```ts
 import {Component} from "@angular/core";
-import {ListFormatPipe} from '@ngxtension/intl';
+import {ListFormatPipe} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -133,7 +133,7 @@ To explore additional configuration settings, you can customize the `ListFormatP
 
 ```ts
 import {Component} from "@angular/core";
-import {ListFormatPipe, provideListFormatOptions} from '@ngxtension/intl';
+import {ListFormatPipe, provideListFormatOptions} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -180,7 +180,7 @@ Import `PluralRulesPipe` and add it to your component:
 
 ```ts
 import {Component} from "@angular/core";
-import {PluralRulesPipe} from '@ngxtension/intl';
+import {PluralRulesPipe} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -208,7 +208,7 @@ To explore additional configuration settings, you can customize the `PluralRules
 
 ```ts
 import {Component} from "@angular/core";
-import {PluralRulesPipe, providePluralRulesOptions} from '@ngxtension/intl';
+import {PluralRulesPipe, providePluralRulesOptions} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -254,7 +254,7 @@ Import `RelativeTimeFormatPipe` and add it to your component:
 
 ```ts
 import {Component} from "@angular/core";
-import {RelativeTimeFormatPipe} from '@ngxtension/intl';
+import {RelativeTimeFormatPipe} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -282,7 +282,7 @@ To explore additional configuration settings, you can customize the `RelativeTim
 
 ```ts
 import {Component} from "@angular/core";
-import {RelativeTimeFormatPipe, provideRelativeTimeFormatOptions} from '@ngxtension/intl';
+import {RelativeTimeFormatPipe, provideRelativeTimeFormatOptions} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',
@@ -329,7 +329,7 @@ Import `SupportedValuesOf` and add it to your component:
 ```ts
 
 import {Component} from "@angular/core";
-import {SupportedValuesOf} from '@ngxtension/intl';
+import {SupportedValuesOf} from 'ngxtension/intl';
 
 @Component({
   selector: 'app-root',

--- a/libs/ngxtension/intl/README.md
+++ b/libs/ngxtension/intl/README.md
@@ -1,0 +1,3 @@
+# ngxtension/intl
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/intl`.

--- a/libs/ngxtension/intl/ng-package.json
+++ b/libs/ngxtension/intl/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/intl/project.json
+++ b/libs/ngxtension/intl/project.json
@@ -1,0 +1,33 @@
+{
+	"name": "ngxtension/intl",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/intl/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["intl"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"libs/ngxtension/intl/**/*.ts",
+					"libs/ngxtension/intl/**/*.html"
+				]
+			}
+		}
+	}
+}

--- a/libs/ngxtension/intl/src/display-names.pipe.ts
+++ b/libs/ngxtension/intl/src/display-names.pipe.ts
@@ -1,0 +1,81 @@
+import {
+	inject,
+	InjectionToken,
+	LOCALE_ID,
+	Pipe,
+	PipeTransform,
+	Provider,
+} from '@angular/core';
+
+type DisplayNamesOptions = Omit<Intl.DisplayNamesOptions, 'type'>;
+
+/**
+ * @internal
+ */
+const defaultOptions: DisplayNamesOptions = {
+	style: 'short',
+	localeMatcher: 'lookup',
+	fallback: 'code',
+};
+
+/**
+ * @internal
+ */
+const DISPLAY_NAMES_INITIALS = new InjectionToken<DisplayNamesOptions>(
+	'DISPLAY_NAMES_INITIALS',
+	{
+		factory: () => defaultOptions,
+	}
+);
+
+/**
+ * Provides a way to inject the options for the DisplayNamesPipe.
+ *
+ * @param options The options to use for the DisplayNamesPipe.
+ * @returns The provider for the DisplayNamesPipe.
+ */
+export function provideDisplayNamesOptions(
+	options: DisplayNamesOptions
+): Provider {
+	return {
+		provide: DISPLAY_NAMES_INITIALS,
+		useValue: { ...defaultOptions, ...options },
+	};
+}
+
+/**
+ * This pipe is a wrapper around the [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) API.
+ *
+ * @returns The display name of the code or the code as it is in case of errors.
+ */
+@Pipe({
+	name: 'displayNames',
+	standalone: true,
+})
+export class DisplayNamesPipe implements PipeTransform {
+	readonly defaultOptions = inject(DISPLAY_NAMES_INITIALS);
+	readonly locale = inject(LOCALE_ID);
+
+	/**
+	 * Displays the name of the given code in the given locale.
+	 *
+	 * @param code The code to transform.
+	 * @param type DisplayNamesType to use.
+	 * @param locale Optional. The locale to use for the transformation. Defaults to LOCALE_ID.
+	 * @returns The name of the given code in the given locale or the code itself if the name could not be found.
+	 */
+	transform(
+		code: string,
+		type: Intl.DisplayNamesType,
+		locale?: string | string[]
+	): ReturnType<Intl.DisplayNames['of']> {
+		try {
+			return new Intl.DisplayNames(locale || this.locale, {
+				...this.defaultOptions,
+				type,
+			}).of(code);
+		} catch (e) {
+			return code;
+		}
+	}
+}

--- a/libs/ngxtension/intl/src/display-names.pipe.ts
+++ b/libs/ngxtension/intl/src/display-names.pipe.ts
@@ -61,18 +61,21 @@ export class DisplayNamesPipe implements PipeTransform {
 	 *
 	 * @param code The code to transform.
 	 * @param type DisplayNamesType to use.
+	 * @param style Optional. The formatting style to use. Defaults to "short".
 	 * @param locale Optional. The locale to use for the transformation. Defaults to LOCALE_ID.
 	 * @returns The name of the given code in the given locale or the code itself if the name could not be found.
 	 */
 	transform(
 		code: string,
 		type: Intl.DisplayNamesType,
+		style?: Intl.DisplayNamesOptions['style'],
 		locale?: string | string[]
 	): ReturnType<Intl.DisplayNames['of']> {
 		try {
 			return new Intl.DisplayNames(locale || this.locale, {
 				...this.defaultOptions,
 				type,
+				...(style ? { style } : {}),
 			}).of(code);
 		} catch (e) {
 			return code;

--- a/libs/ngxtension/intl/src/display-names.pipe.ts
+++ b/libs/ngxtension/intl/src/display-names.pipe.ts
@@ -1,11 +1,11 @@
 import {
 	inject,
-	InjectionToken,
 	LOCALE_ID,
 	Pipe,
 	PipeTransform,
 	Provider,
 } from '@angular/core';
+import { createInjectionToken } from 'ngxtension/create-injection-token';
 
 type DisplayNamesOptions = Omit<Intl.DisplayNamesOptions, 'type'>;
 
@@ -21,12 +21,7 @@ const defaultOptions: DisplayNamesOptions = {
 /**
  * @internal
  */
-const DISPLAY_NAMES_INITIALS = new InjectionToken<DisplayNamesOptions>(
-	'DISPLAY_NAMES_INITIALS',
-	{
-		factory: () => defaultOptions,
-	}
-);
+const [injectFn, provideFn] = createInjectionToken(() => defaultOptions);
 
 /**
  * Provides a way to inject the options for the DisplayNamesPipe.
@@ -35,12 +30,9 @@ const DISPLAY_NAMES_INITIALS = new InjectionToken<DisplayNamesOptions>(
  * @returns The provider for the DisplayNamesPipe.
  */
 export function provideDisplayNamesOptions(
-	options: DisplayNamesOptions
+	options: Partial<DisplayNamesOptions>
 ): Provider {
-	return {
-		provide: DISPLAY_NAMES_INITIALS,
-		useValue: { ...defaultOptions, ...options },
-	};
+	return provideFn({ ...defaultOptions, ...options });
 }
 
 /**
@@ -53,7 +45,7 @@ export function provideDisplayNamesOptions(
 	standalone: true,
 })
 export class DisplayNamesPipe implements PipeTransform {
-	readonly defaultOptions = inject(DISPLAY_NAMES_INITIALS);
+	readonly defaultOptions = injectFn();
 	readonly locale = inject(LOCALE_ID);
 
 	/**
@@ -78,6 +70,7 @@ export class DisplayNamesPipe implements PipeTransform {
 				...(style ? { style } : {}),
 			}).of(code);
 		} catch (e) {
+			console.error(e);
 			return code;
 		}
 	}

--- a/libs/ngxtension/intl/src/display-names.spec.ts
+++ b/libs/ngxtension/intl/src/display-names.spec.ts
@@ -12,6 +12,7 @@ import {
 	template: `
 		<p>{{ 'en-US' | displayNames : 'language' }}</p>
 		<p>{{ 'US' | displayNames : 'region' }}</p>
+		<p>{{ 'US' | displayNames : 'region' : 'long' }}</p>
 	`,
 	imports: [DisplayNamesPipe],
 })
@@ -22,6 +23,7 @@ class TestComponent {}
 	template: `
 		<p>{{ 'en-US' | displayNames : 'language' }}</p>
 		<p>{{ 'US' | displayNames : 'region' }}</p>
+		<p>{{ 'US' | displayNames : 'region' : 'short' }}</p>
 	`,
 	imports: [DisplayNamesPipe],
 	providers: [
@@ -39,6 +41,7 @@ describe(DisplayNamesPipe.name, () => {
 		const elP = fixture.debugElement.queryAll(By.css('p'));
 		expect(elP[0].nativeElement.textContent).toContain('US English');
 		expect(elP[1].nativeElement.textContent).toContain('US');
+		expect(elP[2].nativeElement.textContent).toContain('United States');
 	});
 
 	it('should display the display name of the code with the provided options', () => {
@@ -48,5 +51,6 @@ describe(DisplayNamesPipe.name, () => {
 		const elP = fixture.debugElement.queryAll(By.css('p'));
 		expect(elP[0].nativeElement.textContent).toContain('American English');
 		expect(elP[1].nativeElement.textContent).toContain('United States');
+		expect(elP[2].nativeElement.textContent).toContain('US');
 	});
 });

--- a/libs/ngxtension/intl/src/display-names.spec.ts
+++ b/libs/ngxtension/intl/src/display-names.spec.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import {
+	DisplayNamesPipe,
+	provideDisplayNamesOptions,
+} from './display-names.pipe';
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 'en-US' | displayNames : 'language' }}</p>
+		<p>{{ 'US' | displayNames : 'region' }}</p>
+	`,
+	imports: [DisplayNamesPipe],
+})
+class TestComponent {}
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 'en-US' | displayNames : 'language' }}</p>
+		<p>{{ 'US' | displayNames : 'region' }}</p>
+	`,
+	imports: [DisplayNamesPipe],
+	providers: [
+		// Optional, default options are {style: 'short', localeMatcher: 'lookup', fallback: 'code'}
+		provideDisplayNamesOptions({ style: 'long' }),
+	],
+})
+class TestComponentWithProvider {}
+
+describe(DisplayNamesPipe.name, () => {
+	it('should display the display name of the code', () => {
+		const fixture = TestBed.createComponent(TestComponent);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('US English');
+		expect(elP[1].nativeElement.textContent).toContain('US');
+	});
+
+	it('should display the display name of the code with the provided options', () => {
+		const fixture = TestBed.createComponent(TestComponentWithProvider);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('American English');
+		expect(elP[1].nativeElement.textContent).toContain('United States');
+	});
+});

--- a/libs/ngxtension/intl/src/index.ts
+++ b/libs/ngxtension/intl/src/index.ts
@@ -1,0 +1,5 @@
+export * from './display-names.pipe';
+export * from './list-format.pipe';
+export * from './plural-rules.pipe';
+export * from './relative-time-format.pipe';
+export * from './supportedValuesOf.pipe';

--- a/libs/ngxtension/intl/src/list-format.pipe.ts
+++ b/libs/ngxtension/intl/src/list-format.pipe.ts
@@ -1,11 +1,11 @@
 import {
 	inject,
-	InjectionToken,
 	LOCALE_ID,
 	Pipe,
 	PipeTransform,
 	Provider,
 } from '@angular/core';
+import { createInjectionToken } from 'ngxtension/create-injection-token';
 
 /**
  * @internal
@@ -18,12 +18,7 @@ const defaultOptions: Intl.ListFormatOptions = {
 /**
  * @internal
  */
-const LIST_FORMAT_INITIALS = new InjectionToken<Intl.ListFormatOptions>(
-	'LIST_FORMAT_INITIALS',
-	{
-		factory: () => defaultOptions,
-	}
-);
+const [injectFn, provideFn] = createInjectionToken(() => defaultOptions);
 
 /**
  * Provides a way to inject the options for the ListFormatPipe.
@@ -32,12 +27,9 @@ const LIST_FORMAT_INITIALS = new InjectionToken<Intl.ListFormatOptions>(
  * @returns The provider for the ListFormatPipe.
  */
 export function provideListFormatOptions(
-	options: Intl.ListFormatOptions
+	options: Partial<Intl.ListFormatOptions>
 ): Provider {
-	return {
-		provide: LIST_FORMAT_INITIALS,
-		useValue: { ...defaultOptions, ...options },
-	};
+	return provideFn({ ...defaultOptions, ...options });
 }
 
 /**
@@ -50,7 +42,7 @@ export function provideListFormatOptions(
 	standalone: true,
 })
 export class ListFormatPipe implements PipeTransform {
-	readonly defaultOptions = inject(LIST_FORMAT_INITIALS);
+	readonly defaultOptions = injectFn();
 	readonly locale = inject(LOCALE_ID);
 
 	/**
@@ -72,6 +64,7 @@ export class ListFormatPipe implements PipeTransform {
 				...(style ? { style } : {}),
 			}).format(Array.from(value));
 		} catch (e) {
+			console.error(e);
 			return Array.from(value).join(', ');
 		}
 	}

--- a/libs/ngxtension/intl/src/list-format.pipe.ts
+++ b/libs/ngxtension/intl/src/list-format.pipe.ts
@@ -1,0 +1,73 @@
+import {
+	inject,
+	InjectionToken,
+	LOCALE_ID,
+	Pipe,
+	PipeTransform,
+	Provider,
+} from '@angular/core';
+
+/**
+ * @internal
+ */
+const defaultOptions: Intl.ListFormatOptions = {
+	style: 'long',
+	type: 'conjunction',
+};
+
+/**
+ * @internal
+ */
+const LIST_FORMAT_INITIALS = new InjectionToken<Intl.ListFormatOptions>(
+	'LIST_FORMAT_INITIALS',
+	{
+		factory: () => defaultOptions,
+	}
+);
+
+/**
+ * Provides a way to inject the options for the ListFormatPipe.
+ *
+ * @param options The options to use for the ListFormatPipe.
+ * @returns The provider for the ListFormatPipe.
+ */
+export function provideListFormatOptions(
+	options: Intl.ListFormatOptions
+): Provider {
+	return {
+		provide: LIST_FORMAT_INITIALS,
+		useValue: { ...defaultOptions, ...options },
+	};
+}
+
+/**
+ * This pipe is a wrapper around the [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) API.
+ *
+ * @returns The formatted list of values or the list as string in case of errors.
+ */
+@Pipe({
+	name: 'listFormat',
+	standalone: true,
+})
+export class ListFormatPipe implements PipeTransform {
+	readonly defaultOptions = inject(LIST_FORMAT_INITIALS);
+	readonly locale = inject(LOCALE_ID);
+
+	/**
+	 * Transforms the list of values into a formatted string.
+	 *
+	 * @param value The list of values to format.
+	 * @param locale Optional, the locale to use for the formatting.
+	 * @returns The formatted list of values or the list as string in case of errors.
+	 */
+	transform(value: Iterable<string>, locale?: string | string[]): string {
+		try {
+			return new Intl.ListFormat(
+				locale || this.locale,
+				this.defaultOptions
+			).format(Array.from(value));
+		} catch (e) {
+			return Array.from(value).join(', ');
+		}
+	}
+}

--- a/libs/ngxtension/intl/src/list-format.pipe.ts
+++ b/libs/ngxtension/intl/src/list-format.pipe.ts
@@ -57,15 +57,20 @@ export class ListFormatPipe implements PipeTransform {
 	 * Transforms the list of values into a formatted string.
 	 *
 	 * @param value The list of values to format.
-	 * @param locale Optional, the locale to use for the formatting.
+	 * @param style Optional. The formatting style to use. Defaults to "long".
+	 * @param locale Optional. The locale to use for the transformation. Defaults to LOCALE_ID.
 	 * @returns The formatted list of values or the list as string in case of errors.
 	 */
-	transform(value: Iterable<string>, locale?: string | string[]): string {
+	transform(
+		value: Iterable<string>,
+		style?: Intl.ListFormatOptions['style'],
+		locale?: string | string[]
+	): string {
 		try {
-			return new Intl.ListFormat(
-				locale || this.locale,
-				this.defaultOptions
-			).format(Array.from(value));
+			return new Intl.ListFormat(locale || this.locale, {
+				...this.defaultOptions,
+				...(style ? { style } : {}),
+			}).format(Array.from(value));
 		} catch (e) {
 			return Array.from(value).join(', ');
 		}

--- a/libs/ngxtension/intl/src/list-format.spec.ts
+++ b/libs/ngxtension/intl/src/list-format.spec.ts
@@ -8,6 +8,7 @@ import { ListFormatPipe, provideListFormatOptions } from './list-format.pipe';
 	standalone: true,
 	template: `
 		<p>{{ ['a', 'b', 'c'] | listFormat }}</p>
+		<p>{{ ['a', 'b', 'c'] | listFormat : 'short' }}</p>
 	`,
 	imports: [ListFormatPipe],
 })
@@ -17,11 +18,10 @@ class TestComponent {}
 	standalone: true,
 	template: `
 		<p>{{ ['a', 'b', 'c'] | listFormat }}</p>
+		<p>{{ ['a', 'b', 'c'] | listFormat : 'long' }}</p>
 	`,
 	imports: [ListFormatPipe],
-	providers: [
-		provideListFormatOptions({ style: 'short', type: 'disjunction' }),
-	],
+	providers: [provideListFormatOptions({ style: 'short' })],
 })
 class TestComponentWithProvider {}
 
@@ -30,15 +30,17 @@ describe(ListFormatPipe.name, () => {
 		const fixture = TestBed.createComponent(TestComponent);
 		fixture.detectChanges();
 
-		const elP = fixture.debugElement.query(By.css('p'));
-		expect(elP.nativeElement.textContent).toContain('a, b, and c');
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('a, b, and c');
+		expect(elP[1].nativeElement.textContent).toContain('a, b, & c');
 	});
 
 	it('should display the list of values with the provided options', () => {
 		const fixture = TestBed.createComponent(TestComponentWithProvider);
 		fixture.detectChanges();
 
-		const elP = fixture.debugElement.query(By.css('p'));
-		expect(elP.nativeElement.textContent).toContain('a, b, or c');
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('a, b, & c');
+		expect(elP[1].nativeElement.textContent).toContain('a, b, and c');
 	});
 });

--- a/libs/ngxtension/intl/src/list-format.spec.ts
+++ b/libs/ngxtension/intl/src/list-format.spec.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { ListFormatPipe, provideListFormatOptions } from './list-format.pipe';
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ ['a', 'b', 'c'] | listFormat }}</p>
+	`,
+	imports: [ListFormatPipe],
+})
+class TestComponent {}
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ ['a', 'b', 'c'] | listFormat }}</p>
+	`,
+	imports: [ListFormatPipe],
+	providers: [
+		provideListFormatOptions({ style: 'short', type: 'disjunction' }),
+	],
+})
+class TestComponentWithProvider {}
+
+describe(ListFormatPipe.name, () => {
+	it('should display the list of values', () => {
+		const fixture = TestBed.createComponent(TestComponent);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.query(By.css('p'));
+		expect(elP.nativeElement.textContent).toContain('a, b, and c');
+	});
+
+	it('should display the list of values with the provided options', () => {
+		const fixture = TestBed.createComponent(TestComponentWithProvider);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.query(By.css('p'));
+		expect(elP.nativeElement.textContent).toContain('a, b, or c');
+	});
+});

--- a/libs/ngxtension/intl/src/plural-rules.pipe.ts
+++ b/libs/ngxtension/intl/src/plural-rules.pipe.ts
@@ -1,0 +1,77 @@
+import {
+	inject,
+	InjectionToken,
+	LOCALE_ID,
+	Pipe,
+	PipeTransform,
+	Provider,
+} from '@angular/core';
+
+/**
+ * @internal
+ */
+const defaultOptions: Intl.PluralRulesOptions = {
+	localeMatcher: 'best fit', // other values: "lookup",
+	type: 'cardinal', // other values: "ordinal"
+};
+
+/**
+ * @internal
+ */
+const PLURAL_RULES_INITIALS = new InjectionToken<Intl.PluralRulesOptions>(
+	'PLURAL_RULES_INITIALS',
+	{
+		factory: () => defaultOptions,
+	}
+);
+
+/**
+ * Provides a way to inject the options for the PluralRules.
+ *
+ * @param options The options to use for the PluralRules.
+ * @returns The provider for the PluralRules.
+ */
+export function providePluralRulesOptions(
+	options: Intl.PluralRulesOptions
+): Provider {
+	return {
+		provide: PLURAL_RULES_INITIALS,
+		useValue: { ...defaultOptions, ...options },
+	};
+}
+
+/**
+ * This pipe is a wrapper around the [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) API.
+ * It takes a value and returns the plural category for that value.
+ *
+ * @returns The plural category for the value or the value as string in case of errors.
+ */
+@Pipe({
+	name: 'pluralRules',
+	standalone: true,
+})
+export class PluralRulesPipe implements PipeTransform {
+	readonly defaultOptions = inject(PLURAL_RULES_INITIALS);
+	readonly locale = inject(LOCALE_ID);
+
+	/**
+	 * Transforms the value into a plural category.
+	 *
+	 * @param value The value to transform.
+	 * @param locale Optional, the locale to use for the formatting.
+	 * @returns The plural category for the value or the value as string in case of errors.
+	 */
+	transform(
+		value: number,
+		locale?: string
+	): ReturnType<Intl.PluralRules['select']> | string {
+		try {
+			return new Intl.PluralRules(
+				locale || this.locale,
+				this.defaultOptions
+			).select(value);
+		} catch (e) {
+			return String(value);
+		}
+	}
+}

--- a/libs/ngxtension/intl/src/plural-rules.pipe.ts
+++ b/libs/ngxtension/intl/src/plural-rules.pipe.ts
@@ -1,11 +1,11 @@
 import {
 	inject,
-	InjectionToken,
 	LOCALE_ID,
 	Pipe,
 	PipeTransform,
 	Provider,
 } from '@angular/core';
+import { createInjectionToken } from 'ngxtension/create-injection-token';
 
 /**
  * @internal
@@ -18,12 +18,7 @@ const defaultOptions: Intl.PluralRulesOptions = {
 /**
  * @internal
  */
-const PLURAL_RULES_INITIALS = new InjectionToken<Intl.PluralRulesOptions>(
-	'PLURAL_RULES_INITIALS',
-	{
-		factory: () => defaultOptions,
-	}
-);
+const [injectFn, provideFn] = createInjectionToken(() => defaultOptions);
 
 /**
  * Provides a way to inject the options for the PluralRules.
@@ -32,12 +27,9 @@ const PLURAL_RULES_INITIALS = new InjectionToken<Intl.PluralRulesOptions>(
  * @returns The provider for the PluralRules.
  */
 export function providePluralRulesOptions(
-	options: Intl.PluralRulesOptions
+	options: Partial<Intl.PluralRulesOptions>
 ): Provider {
-	return {
-		provide: PLURAL_RULES_INITIALS,
-		useValue: { ...defaultOptions, ...options },
-	};
+	return provideFn({ ...defaultOptions, ...options });
 }
 
 /**
@@ -51,7 +43,7 @@ export function providePluralRulesOptions(
 	standalone: true,
 })
 export class PluralRulesPipe implements PipeTransform {
-	readonly defaultOptions = inject(PLURAL_RULES_INITIALS);
+	readonly defaultOptions = injectFn();
 	readonly locale = inject(LOCALE_ID);
 
 	/**
@@ -71,6 +63,7 @@ export class PluralRulesPipe implements PipeTransform {
 				this.defaultOptions
 			).select(value);
 		} catch (e) {
+			console.error(e);
 			return String(value);
 		}
 	}

--- a/libs/ngxtension/intl/src/plural-rules.spec.ts
+++ b/libs/ngxtension/intl/src/plural-rules.spec.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import {
+	PluralRulesPipe,
+	providePluralRulesOptions,
+} from './plural-rules.pipe';
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 1 | pluralRules }}</p>
+		<p>{{ 2 | pluralRules }}</p>
+		<p>{{ 3 | pluralRules }}</p>
+	`,
+	imports: [PluralRulesPipe],
+})
+class TestComponent {}
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 1 | pluralRules }}</p>
+		<p>{{ 2 | pluralRules }}</p>
+		<p>{{ 3 | pluralRules }}</p>
+	`,
+	imports: [PluralRulesPipe],
+	providers: [providePluralRulesOptions({ type: 'ordinal' })],
+})
+class TestComponentWithProvider {}
+
+describe(PluralRulesPipe.name, () => {
+	it('should display the plural category of the value', () => {
+		const fixture = TestBed.createComponent(TestComponent);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('one');
+		expect(elP[1].nativeElement.textContent).toContain('other');
+		expect(elP[2].nativeElement.textContent).toContain('other');
+	});
+
+	it('should display the plural category of the value with the provided options', () => {
+		const fixture = TestBed.createComponent(TestComponentWithProvider);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('one');
+		expect(elP[1].nativeElement.textContent).toContain('two');
+		expect(elP[2].nativeElement.textContent).toContain('few');
+	});
+});

--- a/libs/ngxtension/intl/src/relative-time-format.pipe.ts
+++ b/libs/ngxtension/intl/src/relative-time-format.pipe.ts
@@ -1,11 +1,11 @@
 import {
 	inject,
-	InjectionToken,
 	LOCALE_ID,
 	Pipe,
 	PipeTransform,
 	Provider,
 } from '@angular/core';
+import { createInjectionToken } from 'ngxtension/create-injection-token';
 
 /**
  * @internal
@@ -19,13 +19,7 @@ const defaultOptions: Intl.RelativeTimeFormatOptions = {
 /**
  * @internal
  */
-const RELATIVE_TIME_FORMAT_INITIALS =
-	new InjectionToken<Intl.RelativeTimeFormatOptions>(
-		'RELATIVE_TIME_FORMAT_INITIALS',
-		{
-			factory: () => defaultOptions,
-		}
-	);
+const [injectFn, provideFn] = createInjectionToken(() => defaultOptions);
 
 /**
  * Provides a way to inject the options for the RelativeTimeFormatPipe.
@@ -34,12 +28,9 @@ const RELATIVE_TIME_FORMAT_INITIALS =
  * @returns The provider for the RelativeTimeFormatPipe.
  */
 export function provideRelativeTimeFormatOptions(
-	options: Intl.RelativeTimeFormatOptions
+	options: Partial<Intl.RelativeTimeFormatOptions>
 ): Provider {
-	return {
-		provide: RELATIVE_TIME_FORMAT_INITIALS,
-		useValue: { ...defaultOptions, ...options },
-	};
+	return provideFn({ ...defaultOptions, ...options });
 }
 
 /**
@@ -52,7 +43,7 @@ export function provideRelativeTimeFormatOptions(
 	standalone: true,
 })
 export class RelativeTimeFormatPipe implements PipeTransform {
-	readonly defaultOptions = inject(RELATIVE_TIME_FORMAT_INITIALS);
+	readonly defaultOptions = injectFn();
 	readonly locale = inject(LOCALE_ID);
 
 	/**
@@ -76,6 +67,7 @@ export class RelativeTimeFormatPipe implements PipeTransform {
 				...(style ? { style } : {}),
 			}).format(value, unit);
 		} catch (e) {
+			console.error(e);
 			return value.toString();
 		}
 	}

--- a/libs/ngxtension/intl/src/relative-time-format.pipe.ts
+++ b/libs/ngxtension/intl/src/relative-time-format.pipe.ts
@@ -60,19 +60,21 @@ export class RelativeTimeFormatPipe implements PipeTransform {
 	 *
 	 * @param value The value to format.
 	 * @param unit The unit of the value.
+	 * @param style Optional, the formatting style to use.
 	 * @param locale Optional, the locale to use for the formatting.
 	 * @returns The relative time format of the value or the value as it is in case of errors.
 	 */
 	transform(
 		value: number,
 		unit: Intl.RelativeTimeFormatUnit,
+		style?: Intl.RelativeTimeFormatOptions['style'],
 		locale?: string
 	): ReturnType<Intl.RelativeTimeFormat['format']> {
 		try {
-			return new Intl.RelativeTimeFormat(
-				locale || this.locale,
-				this.defaultOptions
-			).format(value, unit);
+			return new Intl.RelativeTimeFormat(locale || this.locale, {
+				...this.defaultOptions,
+				...(style ? { style } : {}),
+			}).format(value, unit);
 		} catch (e) {
 			return value.toString();
 		}

--- a/libs/ngxtension/intl/src/relative-time-format.pipe.ts
+++ b/libs/ngxtension/intl/src/relative-time-format.pipe.ts
@@ -1,0 +1,80 @@
+import {
+	inject,
+	InjectionToken,
+	LOCALE_ID,
+	Pipe,
+	PipeTransform,
+	Provider,
+} from '@angular/core';
+
+/**
+ * @internal
+ */
+const defaultOptions: Intl.RelativeTimeFormatOptions = {
+	localeMatcher: 'best fit', // other values: "lookup"
+	numeric: 'always', // other values: "auto"
+	style: 'long', // other values: "short" or "narrow"
+};
+
+/**
+ * @internal
+ */
+const RELATIVE_TIME_FORMAT_INITIALS =
+	new InjectionToken<Intl.RelativeTimeFormatOptions>(
+		'RELATIVE_TIME_FORMAT_INITIALS',
+		{
+			factory: () => defaultOptions,
+		}
+	);
+
+/**
+ * Provides a way to inject the options for the RelativeTimeFormatPipe.
+ * @param options The options to use for the RelativeTimeFormatPipe.
+ *
+ * @returns The provider for the RelativeTimeFormatPipe.
+ */
+export function provideRelativeTimeFormatOptions(
+	options: Intl.RelativeTimeFormatOptions
+): Provider {
+	return {
+		provide: RELATIVE_TIME_FORMAT_INITIALS,
+		useValue: { ...defaultOptions, ...options },
+	};
+}
+
+/**
+ * This pipe is a wrapper around the [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) API.
+ *
+ * @returns The relative time format of the value or the value as it is in case of errors.
+ */
+@Pipe({
+	name: 'relativeTimeFormat',
+	standalone: true,
+})
+export class RelativeTimeFormatPipe implements PipeTransform {
+	readonly defaultOptions = inject(RELATIVE_TIME_FORMAT_INITIALS);
+	readonly locale = inject(LOCALE_ID);
+
+	/**
+	 * Transforms the value into a relative time format.
+	 *
+	 * @param value The value to format.
+	 * @param unit The unit of the value.
+	 * @param locale Optional, the locale to use for the formatting.
+	 * @returns The relative time format of the value or the value as it is in case of errors.
+	 */
+	transform(
+		value: number,
+		unit: Intl.RelativeTimeFormatUnit,
+		locale?: string
+	): ReturnType<Intl.RelativeTimeFormat['format']> {
+		try {
+			return new Intl.RelativeTimeFormat(
+				locale || this.locale,
+				this.defaultOptions
+			).format(value, unit);
+		} catch (e) {
+			return value.toString();
+		}
+	}
+}

--- a/libs/ngxtension/intl/src/relative-time-format.spec.ts
+++ b/libs/ngxtension/intl/src/relative-time-format.spec.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import {
+	provideRelativeTimeFormatOptions,
+	RelativeTimeFormatPipe,
+} from './relative-time-format.pipe';
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 1 | relativeTimeFormat : 'day' }}</p>
+		<p>{{ -1 | relativeTimeFormat : 'day' }}</p>
+	`,
+	imports: [RelativeTimeFormatPipe],
+})
+class TestComponent {}
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 1 | relativeTimeFormat : 'day' }}</p>
+		<p>{{ -1 | relativeTimeFormat : 'day' }}</p>
+	`,
+	imports: [RelativeTimeFormatPipe],
+	providers: [
+		// Optional, default options are {localeMatcher: 'best fit', numeric: 'always', style: 'long'}
+		provideRelativeTimeFormatOptions({ numeric: 'auto' }),
+	],
+})
+class TestComponentWithProvider {}
+
+describe(RelativeTimeFormatPipe.name, () => {
+	it('should display the relative time format of the value', () => {
+		const fixture = TestBed.createComponent(TestComponent);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('in 1 day');
+		expect(elP[1].nativeElement.textContent).toContain('1 day ago');
+	});
+
+	it('should display the relative time format of the value with the provided options', () => {
+		const fixture = TestBed.createComponent(TestComponentWithProvider);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('tomorrow');
+		expect(elP[1].nativeElement.textContent).toContain('yesterday');
+	});
+});

--- a/libs/ngxtension/intl/src/relative-time-format.spec.ts
+++ b/libs/ngxtension/intl/src/relative-time-format.spec.ts
@@ -11,6 +11,7 @@ import {
 	template: `
 		<p>{{ 1 | relativeTimeFormat : 'day' }}</p>
 		<p>{{ -1 | relativeTimeFormat : 'day' }}</p>
+		<p>{{ 2 | relativeTimeFormat : 'day' : 'short' }}</p>
 	`,
 	imports: [RelativeTimeFormatPipe],
 })
@@ -21,6 +22,7 @@ class TestComponent {}
 	template: `
 		<p>{{ 1 | relativeTimeFormat : 'day' }}</p>
 		<p>{{ -1 | relativeTimeFormat : 'day' }}</p>
+		<p>{{ 2 | relativeTimeFormat : 'day' : 'narrow' }}</p>
 	`,
 	imports: [RelativeTimeFormatPipe],
 	providers: [
@@ -38,6 +40,7 @@ describe(RelativeTimeFormatPipe.name, () => {
 		const elP = fixture.debugElement.queryAll(By.css('p'));
 		expect(elP[0].nativeElement.textContent).toContain('in 1 day');
 		expect(elP[1].nativeElement.textContent).toContain('1 day ago');
+		expect(elP[2].nativeElement.textContent).toContain('in 2 days');
 	});
 
 	it('should display the relative time format of the value with the provided options', () => {
@@ -47,5 +50,6 @@ describe(RelativeTimeFormatPipe.name, () => {
 		const elP = fixture.debugElement.queryAll(By.css('p'));
 		expect(elP[0].nativeElement.textContent).toContain('tomorrow');
 		expect(elP[1].nativeElement.textContent).toContain('yesterday');
+		expect(elP[2].nativeElement.textContent).toContain('in 2d');
 	});
 });

--- a/libs/ngxtension/intl/src/supportedValuesOf.pipe.ts
+++ b/libs/ngxtension/intl/src/supportedValuesOf.pipe.ts
@@ -28,6 +28,7 @@ export class SupportedValuesOf implements PipeTransform {
 		try {
 			return Intl.supportedValuesOf(key);
 		} catch (e) {
+			console.error(e);
 			return [];
 		}
 	}

--- a/libs/ngxtension/intl/src/supportedValuesOf.pipe.ts
+++ b/libs/ngxtension/intl/src/supportedValuesOf.pipe.ts
@@ -1,0 +1,34 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * This pipe is a wrapper around the [Intl.supportedValuesOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf) method.
+ *
+ * @returns An array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
+ */
+@Pipe({
+	name: 'supportedValuesOf',
+	standalone: true,
+})
+export class SupportedValuesOf implements PipeTransform {
+	/**
+	 * Transforms a key into an array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
+	 *
+	 * @param key A key string indicating the category of values to be returned. This is one of: "calendar", "collation", "currency","numberingSystem", "timeZone", "unit"
+	 * @returns An array containing the supported values for the key or an empty array if the input is invalid.
+	 */
+	transform(
+		key:
+			| 'calendar'
+			| 'collation'
+			| 'currency'
+			| 'numberingSystem'
+			| 'timeZone'
+			| 'unit'
+	): string[] {
+		try {
+			return Intl.supportedValuesOf(key);
+		} catch (e) {
+			return [];
+		}
+	}
+}

--- a/libs/ngxtension/intl/src/supportedValuesOf.spec.ts
+++ b/libs/ngxtension/intl/src/supportedValuesOf.spec.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SupportedValuesOf } from './supportedValuesOf.pipe';
+
+@Component({
+	standalone: true,
+	template: `
+		<p>{{ 'currency' | supportedValuesOf }}</p>
+		<p>{{ 'unit' | supportedValuesOf }}</p>
+	`,
+	imports: [SupportedValuesOf],
+})
+class TestComponent {}
+
+describe(SupportedValuesOf.name, () => {
+	it('should display the supported values of the type', () => {
+		const fixture = TestBed.createComponent(TestComponent);
+		fixture.detectChanges();
+
+		const elP = fixture.debugElement.queryAll(By.css('p'));
+		expect(elP[0].nativeElement.textContent).toContain('USD');
+		expect(elP[1].nativeElement.textContent).toContain('meter');
+	});
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
 		"importHelpers": true,
 		"target": "es2015",
 		"module": "esnext",
-		"lib": ["es2020", "dom"],
+		"lib": ["es2020", "dom", "es2023"],
 		"skipLibCheck": true,
 		"skipDefaultLibCheck": true,
 		"baseUrl": ".",
@@ -37,6 +37,7 @@
 			"ngxtension/inject-destroy": [
 				"libs/ngxtension/inject-destroy/src/index.ts"
 			],
+			"ngxtension/intl": ["libs/ngxtension/intl/src/index.ts"],
 			"ngxtension/map-array": ["libs/ngxtension/map-array/src/index.ts"],
 			"ngxtension/navigation-end": [
 				"libs/ngxtension/navigation-end/src/index.ts"


### PR DESCRIPTION
As we've talked, I'm pushing the new `Intl` pipes that I think could be useful.

These are:
* [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) 
* [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat)
* [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules)
* [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat)
* [Intl.supportedValuesOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf)

I've written some tests that cover all helpers.

Fixes #72 