### PR TITLE
feat: add a signal base hostBinding function

### DIFF
--- a/docs/src/content/docs/utilities/host-binding.md
+++ b/docs/src/content/docs/utilities/host-binding.md
@@ -1,0 +1,46 @@
+---
+title: hostBinding
+description: ngxtension/host-binding
+---
+
+`hostBinding` is a function that returns either a _writable_ or _readonly_ signal and binds the value held in that signal to the host property passed as the first argument like `@HostBinding` would do.
+
+```ts
+import { hostBinding } from 'ngxtension/host-binding';
+```
+
+## Usage
+
+With `@HostBinding` you can bind a color from a class property:
+
+```ts
+@Component({
+  standalone: true;
+  selector: 'my-component'
+  template: '...'
+})
+export class MyComponent {
+  @HostBinding('style.color') color = 'red';
+
+  updateColor(color: 'red' | 'blue') {
+    this.color = color;
+  }
+}
+```
+
+With `hostBinding` you can now bind anything like `@HostBinding` on writable or readonly signals:
+
+```ts
+@Component({
+  standalone: true;
+  selector: 'my-component'
+  template: '...'
+})
+export class MyComponent {
+  color = hostBinding('style.color', signal('red'));
+
+  updateColor(color: 'red' | 'blue') {
+    this.color.set(color);
+  }
+}
+```

--- a/libs/ngxtension/host-binding/README.md
+++ b/libs/ngxtension/host-binding/README.md
@@ -1,0 +1,3 @@
+# ngxtension/host-binding
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/host-binding`.

--- a/libs/ngxtension/host-binding/ng-package.json
+++ b/libs/ngxtension/host-binding/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/host-binding/project.json
+++ b/libs/ngxtension/host-binding/project.json
@@ -1,0 +1,33 @@
+{
+	"name": "ngxtension/host-binding",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/host-binding/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["host-binding"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"libs/ngxtension/host-binding/**/*.ts",
+					"libs/ngxtension/host-binding/**/*.html"
+				]
+			}
+		}
+	}
+}

--- a/libs/ngxtension/host-binding/src/host-binding.spec.ts
+++ b/libs/ngxtension/host-binding/src/host-binding.spec.ts
@@ -1,0 +1,165 @@
+import {
+	Component,
+	Injector,
+	OnInit,
+	computed,
+	inject,
+	signal,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { hostBinding } from './host-binding';
+
+type FakeControl = {
+	valid: boolean;
+	value: number[];
+};
+
+@Component({
+	standalone: true,
+	template: '',
+})
+class TestHost {
+	fakeControl = signal<FakeControl>({
+		valid: true,
+		value: [],
+	});
+
+	// class binding
+	valid = hostBinding(
+		'class.valid',
+		computed(() => this.fakeControl().valid)
+	);
+
+	invalid = hostBinding(
+		'class.invalid',
+		computed(() => !this.valid())
+	);
+
+	// style binding
+	color = hostBinding(
+		'style.color',
+		computed(() => (this.valid() ? 'green' : 'red'))
+	);
+
+	// style binding with a style unit extension
+	width = hostBinding('style.width.px', signal(500));
+
+	// attribute binding
+	required = hostBinding('attr.aria-required', signal(false));
+
+	// property binding
+	id = hostBinding(
+		'id',
+		computed(() => (this.fakeControl().value.length ? 'filled' : 'empty'))
+	);
+}
+
+describe(hostBinding.name, () => {
+	const setup = (updatedFakeControl?: Partial<FakeControl>) => {
+		const fixture = TestBed.createComponent(TestHost);
+		fixture.detectChanges();
+
+		if (updatedFakeControl) {
+			fixture.componentInstance.fakeControl.update((ctrl) => ({
+				...ctrl,
+				...updatedFakeControl,
+			}));
+
+			fixture.detectChanges();
+		}
+
+		return { fixture };
+	};
+
+	describe('class binding', () => {
+		it('should bind the "valid" class but no "invalid"', () => {
+			const { fixture } = setup();
+
+			expect(fixture.nativeElement.classList).toContain('valid');
+			expect(fixture.nativeElement.classList).not.toContain('invalid');
+		});
+
+		it('should bind the "invalid" class but no "valid"', () => {
+			const { fixture } = setup({ valid: false });
+
+			expect(fixture.nativeElement.classList).toContain('invalid');
+			expect(fixture.nativeElement.classList).not.toContain('valid');
+		});
+	});
+
+	describe('style binding', () => {
+		it('should bind the "green" color', () => {
+			const { fixture } = setup();
+
+			expect(fixture.nativeElement.style.color).toEqual('green');
+		});
+
+		it('should bind the "red" color', () => {
+			const { fixture } = setup({ valid: false });
+
+			expect(fixture.nativeElement.style.color).toEqual('red');
+		});
+
+		it('should bind the width to "500px"', () => {
+			const { fixture } = setup();
+
+			expect(fixture.nativeElement.style.width).toEqual('500px');
+		});
+	});
+
+	describe('attribute binding', () => {
+		it('should bind the aria-required to "false"', () => {
+			const { fixture } = setup();
+
+			expect(fixture.nativeElement.getAttribute('aria-required')).toEqual(
+				'false'
+			);
+		});
+	});
+
+	describe('propery binding', () => {
+		it('should bind the "empty" id', () => {
+			const { fixture } = setup();
+
+			expect(fixture.nativeElement.id).toEqual('empty');
+		});
+
+		it('should bind the "filled" id', () => {
+			const { fixture } = setup({ value: [1] });
+
+			expect(fixture.nativeElement.id).toEqual('filled');
+		});
+	});
+
+	describe('out of injection context', () => {
+		const component = (
+			options: { addInjector?: boolean } = { addInjector: false }
+		) => {
+			@Component({ standalone: true, template: '' })
+			class Comp implements OnInit {
+				injector = inject(Injector);
+
+				ngOnInit() {
+					hostBinding(
+						'',
+						signal(null),
+						options?.addInjector ? this.injector : undefined
+					);
+				}
+			}
+			return Comp;
+		};
+
+		it('should throw', () => {
+			const fixture = TestBed.createComponent(component());
+
+			expect(() => fixture.detectChanges()).toThrow();
+		});
+
+		it('should not throw', () => {
+			const fixture = TestBed.createComponent(component({ addInjector: true }));
+
+			expect(() => fixture.detectChanges()).not.toThrow();
+		});
+	});
+});

--- a/libs/ngxtension/host-binding/src/host-binding.ts
+++ b/libs/ngxtension/host-binding/src/host-binding.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import {
+	effect,
+	ElementRef,
+	HostBinding,
+	inject,
+	Injector,
+	Renderer2,
+	RendererStyleFlags2,
+	runInInjectionContext,
+	Signal,
+	WritableSignal,
+} from '@angular/core';
+import { assertInjector } from 'ngxtension/assert-injector';
+
+/**
+ * `hostBinding` takes a `hostPropertyName` to attach a data property, a class, a style or an attribute (as `@HostBinding` would) to the host.
+ * The udpate is applied based on the update of the provided signal (writable or not).
+ *
+ * @param {Required<HostBinding>['hostPropertyName']} hostPropertyName - the same property that is bound to a data property, a class, a style or an attribute as `@HostBinding`.
+ * @param {Signal | WritableSignal} signal - the signal on which to react to changes to update the host, and the one that will be returned as it is
+ * @returns {Signal | WritableSignal}
+ *
+ * @example
+ * ```ts
+ * export class MyComponent {
+ *  readonly background = hostBinding('style.background', signal('blue'));
+ *
+ *  constructor() {
+ *    setTimeout(() => this.background.set('red'), 3000);
+ *  }
+ * }
+ * ```
+ */
+export function hostBinding<T, S extends Signal<T> | WritableSignal<T>>(
+	hostPropertyName: Required<HostBinding>['hostPropertyName'],
+	signal: S,
+	injector?: Injector
+): S {
+	injector = assertInjector(hostBinding, injector);
+
+	runInInjectionContext(injector, () => {
+		const renderer = inject(Renderer2);
+		const element = inject(ElementRef).nativeElement;
+
+		effect(() => {
+			const value = signal();
+			const [binding, property, unit] = hostPropertyName.split('.');
+
+			switch (binding) {
+				case 'style':
+					renderer.setStyle(
+						element,
+						property,
+						`${value}${unit ?? ''}`,
+						property.startsWith('--') ? RendererStyleFlags2.DashCase : undefined
+					);
+					break;
+				case 'attr':
+					renderer.setAttribute(element, property, String(value));
+					break;
+				case 'class':
+					if (value) {
+						renderer.addClass(element, property);
+					} else {
+						renderer.removeClass(element, property);
+					}
+					break;
+				default:
+					renderer.setProperty(element, binding, value);
+			}
+		});
+	});
+
+	return signal;
+}

--- a/libs/ngxtension/host-binding/src/index.ts
+++ b/libs/ngxtension/host-binding/src/index.ts
@@ -1,0 +1,1 @@
+export * from './host-binding';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,7 @@
 			"ngxtension/filter-array": ["libs/ngxtension/filter-array/src/index.ts"],
 			"ngxtension/filter-nil": ["libs/ngxtension/filter-nil/src/index.ts"],
 			"ngxtension/gestures": ["libs/ngxtension/gestures/src/index.ts"],
+			"ngxtension/host-binding": ["libs/ngxtension/host-binding/src/index.ts"],
 			"ngxtension/if-validator": ["libs/ngxtension/if-validator/src/index.ts"],
 			"ngxtension/inject-destroy": [
 				"libs/ngxtension/inject-destroy/src/index.ts"


### PR DESCRIPTION
As the title of the pull request suggests I added a `hostBinding` function that can be used to bind properties like `@HostBinding` would, but to signals (either writable or readonly).

As you would do to properties bound with the decorator, you are still able to set/update/mutate the signal if it is writable.

> This is my very first OSS contribution, I hope I didn't mess up :sweat_smile: