### PR TITLE
feat(signal-store): add signalStore from ngrx as a standalone implementation

### DIFF
--- a/docs/src/content/docs/utilities/signal-store.md
+++ b/docs/src/content/docs/utilities/signal-store.md
@@ -1,0 +1,150 @@
+---
+title: signalStore
+description: ngxtension/signal-store
+---
+
+`signalStore` is extracted from [NgRx Signal Store playground](https://github.com/markostanimirovic/ngrx-signal-store-playground) to provide a way to manage a state object using [Angular Signals](https://angular.io/guide/signals)
+
+:::tip[Credits]
+[Marko Stanimirovic](https://twitter.com/MarkoStDev), NgRx Core teeam member, for his initiative (and effort) on Signal Store
+:::
+
+<!-- add caution for ngrx users when ngrx/signals is released -->
+<!-- :::caution -->
+<!-- If you are already using NgRx in your application, it is **recommended** to use these APIs from `@ngrx/signals` -->
+<!-- ::: -->
+
+## `signalStore`
+
+```ts
+import { signalStore } from 'ngxtension/signal-store';
+```
+
+### Usage
+
+`signalStore` returns a store object with the following traits:
+
+- Nested signals
+  - Signals created by `signalStore` use `Object.is` for the equality function.
+- `set` method to update the state
+- `patch` method to apply _non undefined_ states.
+
+```ts
+export class MyComponent {
+	store = signalStore({
+		user: {
+			firstName: 'chau',
+			lastName: 'tran',
+		},
+		foo: 'bar',
+		numbers: [1, 2, 3],
+	});
+
+	constructor() {
+		this.store(); // { user: {firstName: 'chau', lastName: 'tran'}, foo: 'bar', numbers: [1, 2, 3]}
+		this.store.snapshot; // { user: {firstName: 'chau', lastName: 'tran'}, foo: 'bar', numbers: [1, 2, 3]}
+
+		this.store.user; // Signal<{firstName: string, lastName: string}>
+		this.store.user(); // {firstName: 'chau', lastName: 'tran'}
+		this.store.user.firstName(); // 'chau'
+		this.store.numbers(); // [1, 2, 3]
+
+		this.store.set({ foo: 'baz' }); // partial set state
+		this.store.set((state) => ({ numbers: [...state.numbers, 4] })); // functional set state
+	}
+}
+```
+
+#### `patch` behavior
+
+`patch` is an API that should be _rarely_ used. If a value passed in to `patch()` is `undefined`, then that value is skipped
+
+```ts
+export class MyComponent {
+	store = signalStore({ foo: 1, bar: 2 });
+
+	constructor() {
+		this.store.foo(); // 1
+		this.store.bar(); // 2
+
+		this.store.patch({ foo: 3 });
+		this.store.foo(); // 3
+
+		this.store.patch({ foo: undefined, bar: 4 });
+		this.store.foo(); // 3; `undefined` value is skipped
+		this.store.bar(); // 4
+	}
+}
+```
+
+#### `untracked` state update
+
+:::caution
+This API is only for **advanced** use-case. If you are not sure why you need this API, do not use it.
+:::
+
+`signalStore`, by default, runs the update methods normally. However, there are cases where we need to run update methods inside of `untracked`. For example, when we need to update state inside of `effect()` and we are **sure** that our update operation does not cause any circular dependency.
+
+If this is needed, we can use `provideUseUntracked(true)` to override the default behavior.
+
+```ts
+bootstrapApplication(AppComponent, {
+	providers: [provideUseUntracked(true)],
+});
+
+export class MyComponent {
+	store = signalStore({ foo: 'bar' });
+
+	constructor() {
+		effect(() => {
+			// this should work now and won't need `allowSignalWrites: true`
+			store.set({ foo: 'baz' });
+		});
+	}
+}
+```
+
+This also applies to `snapshot`. By default, `snapshot` will be tracked as a dependency if used in `computed` or `effect`. `provideUseUntracked(true)` will exempt `snapshot` from being tracked.
+
+Please note that this API is **advanced** and **optional**. If we need `untracked` behavior, we can always do so **explicitly**
+
+```ts
+untracked(() => this.store.snapshot);
+untracked(() => this.store.set(/* .. */));
+```
+
+#### Injection Context
+
+If we need to use `signalStore` outside of an Injection Context, we can use `signalStoreInjector()` for the 2nd argument of `signalStore`
+
+```ts
+const store = signalStore({ foo: 'bar' }, signalStoreInjector()); // signalStoreInjector(true) to switch to untracked behavior
+```
+
+## `selectSignal`
+
+```ts
+import { selectSignal } from 'ngxtension/signal-store';
+```
+
+### Usage
+
+`selectSignal` is a utility that accepts one or more `Signal` with a `projectorFn` to return a computed `Signal`. The difference between `selectSignal` and `computed` is that `selectSignal` uses `Object.is` as the default equality function.
+
+`selectSignal` also accepts `CreateComputedOptions` so we can override the default equality function as needed.
+
+```ts
+export class MyComponent {
+	store = signalStore({
+		firstName: 'chau',
+		lastName: 'tran',
+	});
+
+	/* prettier-ignore */
+	fullName = selectSignal(
+    this.store.firstName, 
+    this.store.lastName, 
+    (firstName, lastName) => firstName + ' ' + lastName
+  ); // Signal<string>
+}
+```

--- a/libs/ngxtension/signal-store/README.md
+++ b/libs/ngxtension/signal-store/README.md
@@ -1,0 +1,3 @@
+# ngxtension/signal-store
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/signal-store`.

--- a/libs/ngxtension/signal-store/ng-package.json
+++ b/libs/ngxtension/signal-store/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/signal-store/project.json
+++ b/libs/ngxtension/signal-store/project.json
@@ -1,0 +1,33 @@
+{
+	"name": "ngxtension/signal-store",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/signal-store/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["signal-store"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"libs/ngxtension/signal-store/**/*.ts",
+					"libs/ngxtension/signal-store/**/*.html"
+				]
+			}
+		}
+	}
+}

--- a/libs/ngxtension/signal-store/src/deep-signal.ts
+++ b/libs/ngxtension/signal-store/src/deep-signal.ts
@@ -1,0 +1,28 @@
+import { isSignal, untracked, type Signal } from '@angular/core';
+import { selectSignal } from './select-signal';
+
+export type DeepSignal<T> = Signal<T> &
+	(T extends Record<string, unknown>
+		? Readonly<{ [K in keyof T]: DeepSignal<T[K]> }>
+		: unknown);
+
+export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {
+	const value = untracked(signal);
+	if (!isRecord(value)) {
+		return signal as DeepSignal<T>;
+	}
+
+	return new Proxy(signal, {
+		get(target: any, prop) {
+			if (prop in value && !target[prop]) {
+				target[prop] = selectSignal(() => target()[prop]);
+			}
+
+			return isSignal(target[prop]) ? toDeepSignal(target[prop]) : target[prop];
+		},
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value?.constructor === Object;
+}

--- a/libs/ngxtension/signal-store/src/index.ts
+++ b/libs/ngxtension/signal-store/src/index.ts
@@ -1,0 +1,5 @@
+/**
+ * CREDIT to [Marko](https://twitter.com/MarkoStDev) for their work on this
+ */
+export * from './select-signal';
+export * from './signal-store';

--- a/libs/ngxtension/signal-store/src/select-signal.ts
+++ b/libs/ngxtension/signal-store/src/select-signal.ts
@@ -1,0 +1,59 @@
+import {
+	computed,
+	type CreateComputedOptions,
+	type Signal,
+} from '@angular/core';
+
+export function selectSignal<Result>(
+	projector: () => Result,
+	config?: CreateComputedOptions<Result>
+): Signal<Result>;
+export function selectSignal<Signals extends Signal<any>[], Result>(
+	...args: [
+		...signals: Signals,
+		projector: (
+			...values: {
+				[K in keyof Signals]: Signals[K] extends Signal<infer Value>
+					? Value
+					: never;
+			}
+		) => Result
+	]
+): Signal<Result>;
+export function selectSignal<Signals extends Signal<any>[], Result>(
+	...args: [
+		...signals: Signals,
+		projector: (
+			...values: {
+				[K in keyof Signals]: Signals[K] extends Signal<infer Value>
+					? Value
+					: never;
+			}
+		) => Result,
+		config: CreateComputedOptions<Result>
+	]
+): Signal<Result>;
+export function selectSignal<Result>(...args: unknown[]): Signal<Result> {
+	const selectSignalArgs = [...args];
+
+	const config: CreateComputedOptions<Result> =
+		typeof selectSignalArgs[selectSignalArgs.length - 1] === 'object'
+			? (selectSignalArgs.pop() as CreateComputedOptions<Result>)
+			: { equal: defaultEqualityFn };
+	const projector = selectSignalArgs.pop() as (...values: unknown[]) => Result;
+	const signals = selectSignalArgs as Signal<unknown>[];
+
+	const computation =
+		signals.length === 0
+			? projector
+			: () => {
+					const values = signals.map((signal) => signal());
+					return projector(...values);
+			  };
+
+	return computed(computation, config);
+}
+
+export function defaultEqualityFn<T>(previous: T, current: T): boolean {
+	return Object.is(previous, current);
+}

--- a/libs/ngxtension/signal-store/src/signal-store.spec.ts
+++ b/libs/ngxtension/signal-store/src/signal-store.spec.ts
@@ -1,0 +1,95 @@
+import { selectSignal } from './select-signal';
+import { signalStore, signalStoreInjector } from './signal-store';
+
+describe(signalStore.name, () => {
+	const initialState = {
+		user: {
+			firstName: 'John',
+			lastName: 'Smith',
+		},
+		foo: 'bar',
+		numbers: [1, 2, 3],
+	};
+
+	type State = typeof initialState;
+
+	describe('given store with initial state', () => {
+		function setup() {
+			return signalStore(initialState, signalStoreInjector());
+		}
+
+		it('then snapshot should work properly', () => {
+			const store = setup();
+			expect(store.snapshot).toEqual(initialState);
+
+			store.set((state) => ({ numbers: [...state.numbers, 4] }));
+			expect(store.snapshot).toEqual({
+				...initialState,
+				numbers: [...initialState.numbers, 4],
+			});
+			expect(store.snapshot.user).toBe(initialState.user);
+		});
+
+		it('then nested signals should work properly', () => {
+			const store = setup();
+			expect(store.user()).toEqual(initialState.user);
+			expect(store.user.firstName()).toEqual(initialState.user.firstName);
+
+			store.set((state) => ({ user: { ...state.user, firstName: 'chau' } }));
+			expect(store.user()).toEqual({ ...initialState.user, firstName: 'chau' });
+			expect(store.user.firstName()).toEqual('chau');
+		});
+
+		it('then selectSignal should work properly', () => {
+			const store = setup();
+			const fullName = selectSignal(
+				store.user.firstName,
+				store.user.lastName,
+				(firstName, lastName) => `${firstName} ${lastName}`
+			);
+
+			expect(fullName()).toEqual(
+				initialState.user.firstName + ' ' + initialState.user.lastName
+			);
+
+			store.set({ user: { firstName: 'chau', lastName: 'tran' } });
+			expect(fullName()).toEqual('chau tran');
+		});
+	});
+
+	describe('given store with functional initial state', () => {
+		function setup() {
+			return signalStore<State & { setFirstname: (firstName: string) => void }>(
+				({ snapshot, set }) => ({
+					...initialState,
+					setFirstname: (firstName) => {
+						set({ user: { ...snapshot.user, firstName } });
+					},
+				}),
+				signalStoreInjector()
+			);
+		}
+
+		it('then snapshot should work properly', () => {
+			const store = setup();
+			expect(store.snapshot).toEqual({
+				...initialState,
+				setFirstname: expect.any(Function),
+			});
+
+			const setFirstname = store.setFirstname();
+			setFirstname('chau');
+			expect(store.snapshot.user.firstName).toEqual('chau');
+		});
+
+		it('then nested signal should work properly', () => {
+			const store = setup();
+			expect(store.user()).toEqual(initialState.user);
+			expect(store.user.firstName()).toEqual(initialState.user.firstName);
+
+			const setFirstname = store.setFirstname();
+			setFirstname('chau');
+			expect(store.user.firstName()).toEqual('chau');
+		});
+	});
+});

--- a/libs/ngxtension/signal-store/src/signal-store.ts
+++ b/libs/ngxtension/signal-store/src/signal-store.ts
@@ -1,0 +1,157 @@
+import {
+	Injector,
+	WritableSignal,
+	runInInjectionContext,
+	signal,
+	untracked,
+} from '@angular/core';
+import { assertInjector } from 'ngxtension/assert-injector';
+import { createInjectionToken } from 'ngxtension/create-injection-token';
+import { toDeepSignal, type DeepSignal } from './deep-signal';
+import { defaultEqualityFn } from './select-signal';
+
+export type SignalStore<State extends Record<string, unknown>> =
+	DeepSignal<State> & SignalStoreUpdate<State> & SignalStoreSnapshot<State>;
+
+export type SignalStoreSnapshot<State extends Record<string, unknown>> = {
+	snapshot: State;
+};
+
+export type SignalStoreUpdater<State extends Record<string, unknown>> =
+	| Partial<State>
+	| ((state: State) => Partial<State>);
+
+export type SignalStoreUpdate<State extends Record<string, unknown>> = {
+	set: (...updaters: SignalStoreUpdater<State>[]) => void;
+	patch: (state: Partial<State>) => void;
+};
+
+export type SignalStoreApi<State extends Record<string, unknown>> =
+	SignalStoreUpdate<State> & SignalStoreSnapshot<State>;
+
+export const [injectUseUntracked, provideUseUntracked] = createInjectionToken(
+	() => false
+);
+
+export function signalStoreInjector(useUntracked = false) {
+	return Injector.create({ providers: [provideUseUntracked(useUntracked)] });
+}
+
+/**
+ * Signal state cannot contain optional properties.
+ */
+export type NotAllowedStateCheck<State> = State extends Required<State>
+	? State extends Record<string, unknown>
+		? { [K in keyof State]: State[K] & NotAllowedStateCheck<State[K]> }
+		: unknown
+	: never;
+
+export function signalStore<State extends Record<string, unknown>>(
+	initialState:
+		| (State & NotAllowedStateCheck<State>)
+		| ((
+				storeApi: SignalStoreApi<State>
+		  ) => State & NotAllowedStateCheck<State>),
+	injector?: Injector
+): SignalStore<State> {
+	injector = assertInjector(signalStore, injector);
+	return runInInjectionContext(injector, () => {
+		const useUntracked = injectUseUntracked({ optional: true }) ?? false;
+
+		let source: WritableSignal<State>;
+		let set: SignalStoreUpdate<State>['set'];
+		let patch: SignalStoreUpdate<State>['patch'];
+
+		if (typeof initialState === 'function') {
+			source = signal({} as State, { equal: defaultEqualityFn });
+			set = setFactory(source, useUntracked);
+			patch = patchFactory(source, useUntracked);
+
+			const api = { set, patch } as SignalStoreApi<State>;
+
+			Object.defineProperty(api, 'snapshot', {
+				get: snapshotFactory(source, useUntracked),
+				configurable: false,
+			});
+
+			source.set(initialState(api));
+		} else {
+			source = signal(initialState, { equal: defaultEqualityFn });
+			set = setFactory(source, useUntracked);
+			patch = patchFactory(source, useUntracked);
+		}
+
+		const deepSource = toDeepSignal(source.asReadonly());
+		Object.assign(deepSource, { set, patch });
+		Object.defineProperty(deepSource, 'snapshot', {
+			get: snapshotFactory(source, useUntracked),
+			configurable: false,
+		});
+
+		return deepSource as SignalStore<State>;
+	});
+}
+
+function snapshotFactory<State extends Record<string, unknown>>(
+	_source: WritableSignal<State>,
+	useUntracked = false
+) {
+	if (useUntracked) {
+		return () => untracked(_source);
+	}
+	return _source.asReadonly();
+}
+
+function setFactory<State extends Record<string, unknown>>(
+	_source: WritableSignal<State>,
+	useUntracked = false
+): SignalStoreUpdate<State>['set'] {
+	return (...updaters) => {
+		const _updater = (previous: State) => {
+			return updaters.reduce((acc: State, updater) => {
+				const partial = typeof updater === 'function' ? updater(acc) : updater;
+
+				Object.keys(partial).forEach((key) => {
+					const typedKey = key as keyof State;
+					if (partial[typedKey] === undefined && acc[typedKey] != null) {
+						partial[typedKey] = acc[typedKey];
+					}
+				});
+
+				return partial as State;
+			}, previous);
+		};
+
+		if (useUntracked) {
+			untracked(() => {
+				_source.update((previous) => ({ ...previous, ..._updater(previous) }));
+			});
+		} else {
+			_source.update((previous) => ({ ...previous, ..._updater(previous) }));
+		}
+	};
+}
+
+function patchFactory<State extends Record<string, unknown>>(
+	_source: WritableSignal<State>,
+	useUntracked = false
+): SignalStoreUpdate<State>['patch'] {
+	return (state: Partial<State>) => {
+		const updater = (previous: State) => {
+			Object.keys(state).forEach((key) => {
+				const typedKey = key as keyof State;
+				if (state[typedKey] === undefined && previous[typedKey] != null) {
+					state[typedKey] = previous[typedKey];
+				}
+			});
+			return state;
+		};
+		if (useUntracked) {
+			untracked(() => {
+				_source.update((previous) => ({ ...updater(previous), ...previous }));
+			});
+		} else {
+			_source.update((previous) => ({ ...updater(previous), ...previous }));
+		}
+	};
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -44,6 +44,7 @@
 			],
 			"ngxtension/repeat": ["libs/ngxtension/repeat/src/index.ts"],
 			"ngxtension/resize": ["libs/ngxtension/resize/src/index.ts"],
+			"ngxtension/signal-store": ["libs/ngxtension/signal-store/src/index.ts"],
 			"ngxtension/trackby-id-prop": [
 				"libs/ngxtension/trackby-id-prop/src/index.ts"
 			],


### PR DESCRIPTION
Closes #38

Credits: https://github.com/ngrx/platform/discussions/3796

This PR has been made aware to @markostanimirovic and if he's **not** OK with us taking from NgRX, this PR will be closed and we'll think of a different implementation for `signalStore`.