### PR TITLE
feat(assert-injector): add run mode for assertInjector

### DIFF
--- a/docs/src/content/docs/utilities/Injectors/assert-injector.md
+++ b/docs/src/content/docs/utilities/Injectors/assert-injector.md
@@ -32,3 +32,49 @@ export function toSignal<T>(observable: Observable<T>, injector?: Injector): Sig
 	});
 }
 ```
+
+## Assert and run
+
+`assertInjector` can also accept a `runner` which is a function that will be invoked in the Injection Context of the guaranteed `Injector` that it asserts. This usage shortens the CIF by not having to call `runInInjectionContext` explicitly.
+
+```ts
+export function toSignal<T>(observable: Observable<T>, injector?: Injector): Signal<T> {
+	return assertInjector(toSignal, injector, () => {
+		const source = signal<T>(undefined!);
+
+		effect((onCleanup) => {
+			const sub = observable.subscribe((value) => {
+				source.set(value);
+			});
+			onCleanup(() => sub.unsubscribe());
+		});
+
+		return source.asReadonly();
+	});
+}
+```
+
+### Retrieve the asserted `Injector`
+
+Since the `runner` is invoked with the asserted `Injector` context, we can retrieve _that_ `Injector` with `inject(Injector)` in the `runner` body. For example, nested `effect()` might need the `Injector`
+
+```ts
+export function injectFoo(injector?: Injector) {
+	return assertInjector(injectFoo, injector, () => {
+		const assertedInjector = inject(Injector);
+
+		// 👇 the outer effect automatically runs in the Injection Context
+		effect(() => {
+			/* do something for outer effect */
+			effect(
+				() => {
+					/* do something for inner effect */
+				},
+				{ injector: assertedInjector }
+			);
+		});
+
+		return 'foo';
+	});
+}
+```

--- a/libs/ngxtension/assert-injector/src/assert-injector.spec.ts
+++ b/libs/ngxtension/assert-injector/src/assert-injector.spec.ts
@@ -17,10 +17,16 @@ describe(assertInjector.name, () => {
 		return runInInjectionContext(injector, () => inject(token));
 	}
 
+	function injectDummyTwo(injector?: Injector) {
+		return assertInjector(injectDummyTwo, injector, () => inject(token) + 1);
+	}
+
 	it('given no custom injector, when run in injection context, then return value', () => {
 		TestBed.runInInjectionContext(() => {
 			const value = injectDummy();
+			const valueTwo = injectDummyTwo();
 			expect(value).toEqual(1);
+			expect(valueTwo).toEqual(2);
 		});
 	});
 
@@ -28,18 +34,28 @@ describe(assertInjector.name, () => {
 		expect(() => injectDummy()).toThrowError(
 			/injectDummy\(\) can only be used within an injection context/i
 		);
+		expect(() => injectDummyTwo()).toThrowError(
+			/injectDummyTwo\(\) can only be used within an injection context/i
+		);
 	});
 
 	it('given a custom injector, when run in that injector context without providing number, then throw', () => {
 		expect(() => injectDummy(Injector.create({ providers: [] }))).toThrowError(
 			/No provider for InjectionToken/i
 		);
+		expect(() =>
+			injectDummyTwo(Injector.create({ providers: [] }))
+		).toThrowError(/No provider for InjectionToken/i);
 	});
 
 	it('given a custom injector, when run in that injector context and providing number, then return value', () => {
 		const value = injectDummy(
 			Injector.create({ providers: [{ provide: token, useValue: 2 }] })
 		);
+		const valueTwo = injectDummyTwo(
+			Injector.create({ providers: [{ provide: token, useValue: 2 }] })
+		);
 		expect(value).toEqual(2);
+		expect(valueTwo).toEqual(3);
 	});
 });

--- a/libs/ngxtension/assert-injector/src/assert-injector.ts
+++ b/libs/ngxtension/assert-injector/src/assert-injector.ts
@@ -1,5 +1,36 @@
-import { Injector, assertInInjectionContext, inject } from '@angular/core';
+import {
+	Injector,
+	assertInInjectionContext,
+	inject,
+	runInInjectionContext,
+} from '@angular/core';
 
+/**
+ * `assertInjector` extends `assertInInjectionContext` with an optional `Injector`
+ * After assertion, `assertInjector` runs the `runner` function with the guaranteed `Injector`
+ * whether it is the default `Injector` within the current **Injection Context**
+ * or the custom `Injector` that was passed in.
+ *
+ * @template {() => any} Runner - Runner is a function that can return anything
+ * @param {Function} fn - the Function to pass in `assertInInjectionContext`
+ * @param {Injector | undefined | null} injector - the optional "custom" Injector
+ * @param {Runner} runner - the runner fn
+ * @returns {ReturnType<Runner>} result - returns the result of the Runner
+ *
+ * @example
+ * ```ts
+ * function injectValue(injector?: Injector) {
+ *  return assertInjector(injectValue, injector, () => 'value');
+ * }
+ *
+ * injectValue(); // string
+ * ```
+ */
+export function assertInjector<Runner extends () => any>(
+	fn: Function,
+	injector: Injector | undefined | null,
+	runner: Runner
+): ReturnType<Runner>;
 /**
  * `assertInjector` extends `assertInInjectionContext` with an optional `Injector`
  * After assertion, `assertInjector` returns a guaranteed `Injector` whether it is the default `Injector`
@@ -23,7 +54,15 @@ import { Injector, assertInInjectionContext, inject } from '@angular/core';
 export function assertInjector(
 	fn: Function,
 	injector: Injector | undefined | null
-): Injector {
+): Injector;
+export function assertInjector(
+	fn: Function,
+	injector: Injector | undefined | null,
+	runner?: () => any
+) {
 	!injector && assertInInjectionContext(fn);
-	return injector ?? inject(Injector);
+	const assertedInjector = injector ?? inject(Injector);
+
+	if (!runner) return assertedInjector;
+	return runInInjectionContext(assertedInjector, runner);
 }


### PR DESCRIPTION
This PR adds an overload for `assertInjector` where it can accept a `runner` function. This overload shortens the userland code by not having the userland code to call `runInInjectionContext` explicitly.