### PR TITLE
feat(map-skip-undefined): add mapSkipUndefined + filterUndefined operator

### DIFF
--- a/docs/src/content/docs/utilities/Operators/map-skip-undefined.md
+++ b/docs/src/content/docs/utilities/Operators/map-skip-undefined.md
@@ -1,0 +1,43 @@
+---
+title: mapSkipUndefined
+description: An RxJS operator that allows applying a transform function to each value of the observable in (same as map), but with the ability to skip (filter out) some values if the function explicitly returns undefined or simply doesn't return anything for same code-path (implicit return undefined).
+---
+
+## Import
+
+```ts
+import { mapSkipUndefined } from 'ngxtension/map-skip-undefined';
+```
+
+## Usage
+
+You can use it as a normal map operator, but with the ability to skip some values: returning undefined (explicit or implicit).
+
+```ts
+import { from } from 'rxjs';
+import { mapSkipUndefined } from 'ngxtension/map-skip-undefined';
+
+const in$ = from([1, 42, 3]);
+const out$ = in$.pipe(
+	mapSkipUndefined((n) => {
+		if (n % 2) return String(n * 2);
+		//else return undefined // <-- this is the same as not returning anything!
+		//In either case the even value is filtered out
+	})
+); //infer Observable<string>
+
+out$.subscribe(console.log); // logs: 2, 6
+```
+
+## Bonus: filterUndefined
+
+If you need to filter out `undefined` value from and Observable stream you can use the `filterUndefined` operator.
+
+### Example
+
+```ts
+import { filterUndefined } from 'ngxtension/map-skip-undefined';
+
+const source$ = of(null, undefined, 42);
+const filtered$ = source$.pipe(filterUndefined()); //emit only null and 42
+```

--- a/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.ts
@@ -42,7 +42,9 @@ export interface InjectIsIntersectingOptions {
  *   }
  * }
  */
-export const injectIsIntersecting = ({ element, injector }: InjectIsIntersectingOptions = {}) => {
+export const injectIsIntersecting = (
+	options: InjectIsIntersectingOptions = {}
+) => {
 	const injector = assertInjector(injectDestroy, options?.injector);
 
 	return runInInjectionContext(injector, () => {

--- a/libs/ngxtension/map-skip-undefined/README.md
+++ b/libs/ngxtension/map-skip-undefined/README.md
@@ -1,0 +1,3 @@
+# ngxtension/map-skip-undefined
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/map-skip-undefined`.

--- a/libs/ngxtension/map-skip-undefined/ng-package.json
+++ b/libs/ngxtension/map-skip-undefined/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/map-skip-undefined/project.json
+++ b/libs/ngxtension/map-skip-undefined/project.json
@@ -1,0 +1,33 @@
+{
+	"name": "ngxtension/map-skip-undefined",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/map-skip-undefined/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["map-skip-undefined"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"libs/ngxtension/map-skip-undefined/**/*.ts",
+					"libs/ngxtension/map-skip-undefined/**/*.html"
+				]
+			}
+		}
+	}
+}

--- a/libs/ngxtension/map-skip-undefined/src/index.ts
+++ b/libs/ngxtension/map-skip-undefined/src/index.ts
@@ -1,0 +1,1 @@
+export * from './map-skip-undefined';

--- a/libs/ngxtension/map-skip-undefined/src/map-skip-undefined.spec.ts
+++ b/libs/ngxtension/map-skip-undefined/src/map-skip-undefined.spec.ts
@@ -1,0 +1,58 @@
+import { from, of, toArray } from 'rxjs';
+import { filterUndefined, mapSkipUndefined } from './map-skip-undefined';
+
+describe(filterUndefined.name, () => {
+	it('given an observable of null, undefined, 42, filter out the undefined, emit null and 42', (done) => {
+		const in$ = of(null, undefined, 42);
+		const out$ = in$.pipe(filterUndefined());
+
+		out$.pipe(toArray()).subscribe((r) => {
+			expect(r).toEqual([null, 42]);
+			done();
+		});
+	});
+});
+
+describe(mapSkipUndefined.name, () => {
+	it('given an observable >1-42-3| and a mapping function that double ONLY the odds value, then result is an observable of >"2"--"6"-| the intial even value (42) is not mapped and so filtered out', (done) => {
+		const in$ = from([1, 42, 3]);
+		const out$ = in$.pipe(
+			mapSkipUndefined((n) => {
+				if (n % 2) return String(n * 2);
+				else return undefined; // explict return undefined to skipout (filter) some value from the out observable
+			})
+		);
+
+		out$.pipe(toArray()).subscribe((r) => {
+			expect(r).toEqual(['2', '6']);
+			done();
+		});
+	});
+
+	it('given a trasform function that always emit values (ex: v => v+42), all value in are "mapped" out: Observable >1-2-3-| -> >43-44-45-| same as map', (done) => {
+		const in$ = from([1, 2, 3]);
+		const out$ = in$.pipe(mapSkipUndefined((n) => n + 42));
+		out$.pipe(toArray()).subscribe((r) => {
+			expect(r).toEqual([43, 44, 45]);
+			done();
+		});
+	});
+
+	it('given a trasform function that explicit return undefined or does not return a value for same code path it filter out those value from the out observable', (done) => {
+		const in$ = from([1, 2, 3, 4, 5, 6, 7]);
+		const doubleNotMultipleOf2Or3$ = in$.pipe(
+			mapSkipUndefined((n) => {
+				if (n % 2) {
+					if (n % 3) return n * 2;
+					else return undefined;
+				}
+				//else return undefined // <-- this is the same as not returning anything! In either case the value is filtered out
+			})
+		);
+
+		doubleNotMultipleOf2Or3$.pipe(toArray()).subscribe((r) => {
+			expect(r).toEqual([2, 10, 14]);
+			done();
+		});
+	});
+});

--- a/libs/ngxtension/map-skip-undefined/src/map-skip-undefined.ts
+++ b/libs/ngxtension/map-skip-undefined/src/map-skip-undefined.ts
@@ -1,0 +1,13 @@
+import { type Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+
+export const filterUndefined = <T>() =>
+	filter((value: T): value is Exclude<T, undefined> => value !== undefined);
+
+export function mapSkipUndefined<T, R>(
+	fnTrasformSkipUndefined: (value: T) => R
+) {
+	return function (source: Observable<T>) {
+		return source.pipe(map(fnTrasformSkipUndefined), filterUndefined());
+	};
+}

--- a/libs/ngxtension/tsconfig.spec.json
+++ b/libs/ngxtension/tsconfig.spec.json
@@ -5,6 +5,7 @@
 		"verbatimModuleSyntax": false,
 		"module": "commonjs",
 		"target": "es2016",
+		"noImplicitReturns": false,
 		"types": ["jest", "node"]
 	},
 	"files": ["src/test-setup.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -46,6 +46,9 @@
 			],
 			"ngxtension/intl": ["libs/ngxtension/intl/src/index.ts"],
 			"ngxtension/map-array": ["libs/ngxtension/map-array/src/index.ts"],
+			"ngxtension/map-skip-undefined": [
+				"libs/ngxtension/map-skip-undefined/src/index.ts"
+			],
 			"ngxtension/navigation-end": [
 				"libs/ngxtension/navigation-end/src/index.ts"
 			],


### PR DESCRIPTION
This PR substitute #101 to add `mapSkipUndefined` and `filterUndefined` instead of old `mapFilter` proposed in #34
I also added simplified tests using `toArray()` as suggested by @tomalaforge + docs for both operators.
Hope this can be accepted.