### PR TITLE
docs: add trackBy hint to repeat util

### DIFF
--- a/docs/src/content/docs/utilities/Directives/repeat.md
+++ b/docs/src/content/docs/utilities/Directives/repeat.md
@@ -13,7 +13,7 @@ import { Repeat } from 'ngxtension/repeat';
 
 ### Basic
 
-Use the `Repeat` directive as an extension of Angular's `NgFor` to iterate over a fixed number of iterations.
+Use the `Repeat` directive as an extension of Angular's `NgFor` to iterate over a fixed number of iterations. The [`TrackByFunction`](https://angular.io/api/core/TrackByFunction) is automatically set to efficiently iterate.
 
 ```ts
 import { Component } from '@angular/core';


### PR DESCRIPTION
When I added the `repeat` util to my code I was wondering if I still had to add a `TrackByFunction` as well - after checking the code I now know that it's not needed.

This change should clarify this for other users.