### PR TITLE
(#130) fix(host-binding): handle the setting of a class without a property

### DIFF
--- a/libs/ngxtension/host-binding/src/host-binding.spec.ts
+++ b/libs/ngxtension/host-binding/src/host-binding.spec.ts
@@ -10,6 +10,7 @@ import { TestBed } from '@angular/core/testing';
 import { hostBinding } from './host-binding';
 
 type FakeControl = {
+	klass?: string | null;
 	valid: boolean;
 	value: number[];
 };
@@ -20,6 +21,7 @@ type FakeControl = {
 })
 class TestHost {
 	fakeControl = signal<FakeControl>({
+		klass: 'hidden something',
 		valid: true,
 		value: [],
 	});
@@ -33,6 +35,11 @@ class TestHost {
 	invalid = hostBinding(
 		'class.invalid',
 		computed(() => !this.valid())
+	);
+
+	klass = hostBinding(
+		'class',
+		computed(() => this.fakeControl().klass)
 	);
 
 	// style binding
@@ -57,16 +64,14 @@ class TestHost {
 describe(hostBinding.name, () => {
 	const setup = (updatedFakeControl?: Partial<FakeControl>) => {
 		const fixture = TestBed.createComponent(TestHost);
-		fixture.detectChanges();
 
 		if (updatedFakeControl) {
 			fixture.componentInstance.fakeControl.update((ctrl) => ({
 				...ctrl,
 				...updatedFakeControl,
 			}));
-
-			fixture.detectChanges();
 		}
+		fixture.detectChanges();
 
 		return { fixture };
 	};
@@ -84,6 +89,27 @@ describe(hostBinding.name, () => {
 
 			expect(fixture.nativeElement.classList).toContain('invalid');
 			expect(fixture.nativeElement.classList).not.toContain('valid');
+		});
+
+		it('should bind the "hidden" and "something classes', () => {
+			const { fixture } = setup();
+
+			expect(fixture.nativeElement.classList).toContain('hidden');
+			expect(fixture.nativeElement.classList).toContain('something');
+		});
+
+		it('should not bind both the "hidden" and "somehting" classes', () => {
+			const { fixture } = setup({ klass: null });
+
+			expect(fixture.nativeElement.classList).not.toContain('hidden');
+			expect(fixture.nativeElement.classList).not.toContain('something');
+		});
+
+		it('should not bind the "hidden" class', () => {
+			const { fixture } = setup({ klass: 'something' });
+
+			expect(fixture.nativeElement.classList).not.toContain('hidden');
+			expect(fixture.nativeElement.classList).toContain('something');
 		});
 	});
 

--- a/libs/ngxtension/host-binding/src/host-binding.ts
+++ b/libs/ngxtension/host-binding/src/host-binding.ts
@@ -41,9 +41,10 @@ export function hostBinding<T, S extends Signal<T> | WritableSignal<T>>(
 
 	runInInjectionContext(injector, () => {
 		const renderer = inject(Renderer2);
-		const element = inject(ElementRef).nativeElement;
+		const element: HTMLElement = inject(ElementRef).nativeElement;
 
 		effect(() => {
+			let prevClasses: string[] = [];
 			const value = signal();
 			const [binding, property, unit] = hostPropertyName.split('.');
 
@@ -60,10 +61,19 @@ export function hostBinding<T, S extends Signal<T> | WritableSignal<T>>(
 					renderer.setAttribute(element, property, String(value));
 					break;
 				case 'class':
-					if (value) {
-						renderer.addClass(element, property);
+					if (!property) {
+						if (prevClasses.length) {
+							prevClasses.forEach((k) => renderer.removeClass(element, k));
+						}
+						prevClasses =
+							typeof value === 'string' ? value.split(' ').filter(Boolean) : [];
+						prevClasses.forEach((k) => renderer.addClass(element, k));
 					} else {
-						renderer.removeClass(element, property);
+						if (value) {
+							renderer.addClass(element, property);
+						} else {
+							renderer.removeClass(element, property);
+						}
 					}
 					break;
 				default:


### PR DESCRIPTION
This PR is a fix to #130 