### PR TITLE
docs: fix documentation link in README

### DIFF
--- a/libs/ngxtension/README.md
+++ b/libs/ngxtension/README.md
@@ -33,6 +33,6 @@ nx generate ngxtension:init
 
 <!-- UTILITIES:START -->
 
-Check [the documentation](https://ngxtension.netlify.app/utilities/assert-injector/).
+Check [the documentation](https://ngxtension.netlify.app/).
 
 <!-- UTILITIES:END -->


### PR DESCRIPTION
Current link in README (https://ngxtension.netlify.app/utilities/assert-injector/) is an invalid URL. Changed it to point to homepage.