### PR TITLE
docs: fix link

### DIFF
--- a/docs/src/content/docs/utilities/Directives/resize.mdx
+++ b/docs/src/content/docs/utilities/Directives/resize.mdx
@@ -8,7 +8,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 ## Import
 
 ```ts
-import { NgxResize, injectResize } from 'ngxtension/ngx-resize';
+import { NgxResize, injectResize } from 'ngxtension/resize';
 ```
 
 `resize` entry point exposes 2 symbols:


### PR DESCRIPTION
the resize documentation had a wrong import link