### PR TITLE
feat(signal-slice): add effects config

### DIFF
--- a/docs/src/content/docs/utilities/Signals/signal-slice.md
+++ b/docs/src/content/docs/utilities/Signals/signal-slice.md
@@ -160,6 +160,13 @@ state = signalSlice({
 			// side effect to save checklists
 			console.log(state.checklists());
 		},
+		withCleanup: () => {
+			// side effect to save checklists
+			console.log(state.checklists());
+			return () => {
+				console.log('clean up');
+			};
+		},
 	}),
 });
 ```
@@ -177,3 +184,10 @@ state().checklists;
 ```
 
 If you do, all of your effects will be triggered whenever _anything_ in the state signal updates.
+
+The `effects` are available on the `SignalSlice` as `EffectRef` so you can terminate the effects preemptively if you choose to do so
+
+```ts
+state.saveChecklists.destroy();
+//      👆 EffectRef
+```

--- a/docs/src/content/docs/utilities/Signals/signal-slice.md
+++ b/docs/src/content/docs/utilities/Signals/signal-slice.md
@@ -134,3 +134,46 @@ This will also make these additional computed values available on the state obje
 ```ts
 this.state.loadedAndError();
 ```
+
+## Effects
+
+It is possible to define signal effects within `signalSlice` itself. This just
+uses a standard `effect` behind the scenes, but it provides the benefit of
+allowing you to define your effects alongside all your other state concerns
+rather than having to have them separately in a `constructor` or field
+initialiser:
+
+```ts
+state = signalSlice({
+	initialState: this.initialState,
+	sources: [this.sources$],
+	reducers: {
+		add: (state, checklist: AddChecklist) => ({
+			checklists: [...state.checklists, this.addIdToChecklist(checklist)],
+		}),
+	},
+	effects: (state) => ({
+		init: () => {
+			console.log('hello');
+		},
+		saveChecklists: () => {
+			// side effect to save checklists
+			console.log(state.checklists());
+		},
+	}),
+});
+```
+
+Make sure that you access the state in effects using your `selectors`:
+
+```ts
+state.checklists();
+```
+
+**NOT** directly using the state signal:
+
+```ts
+state().checklists;
+```
+
+If you do, all of your effects will be triggered whenever _anything_ in the state signal updates.

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -136,7 +136,7 @@ describe(signalSlice.name, () => {
 					},
 					effects: (state) => ({
 						doSomething: () => {
-							testFn(state().age);
+							testFn(state.age());
 						},
 					}),
 				});

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -147,5 +147,33 @@ describe(signalSlice.name, () => {
 				expect(testFn).toHaveBeenCalledWith(initialState.age + 1);
 			});
 		});
+
+		xit('should only run effect with updated signal', () => {
+			// TODO: enable this test when flushEffects is available
+			TestBed.runInInjectionContext(() => {
+				const initFn = jest.fn();
+				const testFn = jest.fn();
+
+				const state = signalSlice({
+					initialState,
+					reducers: {
+						increaseAge: (state) => ({ age: state.age + 1 }),
+					},
+					effects: (state) => ({
+						init: () => {
+							initFn();
+						},
+						doSomething: () => {
+							testFn(state.age());
+						},
+					}),
+				});
+
+				state.increaseAge();
+
+				expect(initFn).toHaveBeenCalledTimes(1);
+				expect(testFn).toHaveBeenCalledTimes(2);
+			});
+		});
 	});
 });

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -13,7 +13,7 @@ describe(signalSlice.name, () => {
 	};
 
 	describe('initialState', () => {
-		let state: SignalSlice<typeof initialState, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -36,7 +36,7 @@ describe(signalSlice.name, () => {
 		const testSource$ = new Subject<Partial<typeof initialState>>();
 		const testSource2$ = new Subject<Partial<typeof initialState>>();
 
-		let state: SignalSlice<typeof initialState, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -119,6 +119,32 @@ describe(signalSlice.name, () => {
 				});
 
 				expect(state.doubleAge()).toEqual(state().age * 2);
+			});
+		});
+	});
+
+	describe('effects', () => {
+		xit('should create effects for named effects', () => {
+			// TODO: enable this test when flushEffects is available
+			TestBed.runInInjectionContext(() => {
+				const testFn = jest.fn();
+
+				const state = signalSlice({
+					initialState,
+					reducers: {
+						increaseAge: (state) => ({ age: state.age + 1 }),
+					},
+					effects: (state) => ({
+						doSomething: () => {
+							testFn(state().age);
+						},
+					}),
+				});
+
+				state.increaseAge();
+
+				expect(testFn).toHaveBeenCalledWith(initialState.age);
+				expect(testFn).toHaveBeenCalledWith(initialState.age + 1);
 			});
 		});
 	});

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -4,6 +4,7 @@ import {
 	effect,
 	inject,
 	signal,
+	type EffectRef,
 	type Signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -19,7 +20,7 @@ type NamedSelectors = {
 };
 
 type NamedEffects = {
-	[selectorName: string]: () => void;
+	[selectorName: string]: () => void | (() => void);
 };
 
 type Selectors<TSignalValue> = {
@@ -31,7 +32,7 @@ type ExtraSelectors<TSelectors extends NamedSelectors> = {
 };
 
 type Effects<TEffects extends NamedEffects> = {
-	[K in keyof TEffects]: () => void;
+	[K in keyof TEffects]: EffectRef;
 };
 
 type ActionMethods<
@@ -86,12 +87,19 @@ export function signalSlice<
 	) => TEffects;
 }): SignalSlice<TSignalValue, TReducers, TSelectors, TEffects> {
 	const destroyRef = inject(DestroyRef);
+
 	const {
 		initialState,
 		sources = [],
 		reducers = {},
-		selectors,
-		effects,
+		selectors = (() => ({})) as unknown as Exclude<
+			(typeof config)['selectors'],
+			undefined
+		>,
+		effects = (() => ({})) as unknown as Exclude<
+			(typeof config)['effects'],
+			undefined
+		>,
 	} = config;
 
 	const state = signal(initialState);
@@ -124,39 +132,38 @@ export function signalSlice<
 	}
 
 	for (const key in initialState) {
-		Object.defineProperties(readonlyState, {
-			[key]: { value: computed(() => readonlyState()[key]) },
+		Object.defineProperty(readonlyState, key, {
+			value: computed(() => readonlyState()[key]),
 		});
 	}
 
-	if (selectors) {
-		for (const [key, selector] of Object.entries(
-			selectors(readonlyState) as TSelectors
-		)) {
-			Object.defineProperties(readonlyState, {
-				[key]: { value: computed(() => selector()) },
-			});
-		}
+	for (const [key, selector] of Object.entries(selectors(readonlyState))) {
+		Object.defineProperty(readonlyState, key, {
+			value: computed(selector),
+		});
 	}
 
-	if (effects) {
-		for (const namedEffect of Object.values(
-			effects(
-				readonlyState as SignalSlice<TSignalValue, TReducers, TSelectors, any>
-			) as TEffects
-		)) {
-			effect(namedEffect);
-		}
+	const slice = readonlyState as SignalSlice<
+		TSignalValue,
+		TReducers,
+		TSelectors,
+		TEffects
+	>;
+
+	for (const [key, namedEffect] of Object.entries(effects(slice))) {
+		Object.defineProperty(slice, key, {
+			value: effect((onCleanup) => {
+				const maybeCleanup = namedEffect();
+				if (maybeCleanup) {
+					onCleanup(() => maybeCleanup());
+				}
+			}),
+		});
 	}
 
 	destroyRef.onDestroy(() => {
 		subs.forEach((sub) => sub.complete());
 	});
 
-	return readonlyState as SignalSlice<
-		TSignalValue,
-		TReducers,
-		TSelectors,
-		TEffects
-	>;
+	return slice;
 }

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -81,7 +81,9 @@ export function signalSlice<
 	sources?: Array<Observable<PartialOrValue<TSignalValue>>>;
 	reducers?: TReducers;
 	selectors?: (state: Signal<TSignalValue>) => TSelectors;
-	effects?: (state: Signal<TSignalValue>) => TEffects;
+	effects?: (
+		state: SignalSlice<TSignalValue, TReducers, TSelectors, any>
+	) => TEffects;
 }): SignalSlice<TSignalValue, TReducers, TSelectors, TEffects> {
 	const destroyRef = inject(DestroyRef);
 	const {
@@ -139,7 +141,9 @@ export function signalSlice<
 
 	if (effects) {
 		for (const namedEffect of Object.values(
-			effects(readonlyState) as TEffects
+			effects(
+				readonlyState as SignalSlice<TSignalValue, TReducers, TSelectors, any>
+			) as TEffects
 		)) {
 			effect(namedEffect);
 		}


### PR DESCRIPTION
This adds an `effects` config to `signalSlice`. It uses the standard signal `effect` internally, this just allows you to define your effects within the `signalSlice` definition rather than having to define them separately in a `constructor` or field initialiser:

```ts
state = signalSlice({
	initialState: this.initialState,
	sources: [this.sources$],
	reducers: {
		add: (state, checklist: AddChecklist) => ({
			checklists: [...state.checklists, this.addIdToChecklist(checklist)],
		}),
	},
	effects: (state) => ({
		init: () => {
			console.log('hello');
		},
		saveChecklists: () => {
			// side effect to save checklists
			console.log(state.checklists());
		},
	}),
});
```

Note that I have added but disabled tests for this feature pending the ability to use `flushEffects`