### PR TITLE
feat(signal-slice): add asyncReducers

### DIFF
--- a/docs/src/content/docs/utilities/Signals/signal-slice.md
+++ b/docs/src/content/docs/utilities/Signals/signal-slice.md
@@ -101,6 +101,30 @@ The associated action can then be triggered with:
 this.state.toggleActive();
 ```
 
+## Async Reducers
+
+A standard reducer accepts a function that updates the state synchronously. It
+is also possible to specify `asyncReducers` that return an observable to update
+the state asynchronously.
+
+For example:
+
+```ts
+  state = signalSlice({
+    initialState: this.initialState,
+    asyncReducers: {
+      load: ($: Observable<void>) => $.pipe(
+        switchMap(() => this.someService.load()),
+        map(data => ({ someProperty: data })
+      )
+    }
+  })
+```
+
+In this particular case, a `load` action will be created that can be called with `this.state.load()`. When this action is called the internal `Subject` will be nexted, and it is this subject that is being supplied as the `$` parameter above. You can then `pipe` onto that `$` to perform whatever asynchronous operations you need, and then at the end you should `map` the result to whatever parts of the state signal you want to update (just like with standard `reducers`).
+
+**NOTE:** This example covers the use case where data _needs_ to be manually triggered with a `load()` action. It is also possible to just have your data load automatically — in this case the observable that loads the data can just be supplied directly through `sources` and it will be loaded automatically without needing to trigger the `load()` action.
+
 ## Action Streams
 
 The source/stream for each action is also exposed on the state object. That means that you can access:

--- a/docs/src/content/docs/utilities/Signals/signal-slice.md
+++ b/docs/src/content/docs/utilities/Signals/signal-slice.md
@@ -113,7 +113,7 @@ For example:
   state = signalSlice({
     initialState: this.initialState,
     asyncReducers: {
-      load: ($: Observable<void>) => $.pipe(
+      load: (_state, $: Observable<void>) => $.pipe(
         switchMap(() => this.someService.load()),
         map(data => ({ someProperty: data })
       )

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { Subject } from 'rxjs';
+import { Observable, Subject, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { SignalSlice, signalSlice } from './signal-slice';
 
 describe(signalSlice.name, () => {
@@ -13,7 +14,7 @@ describe(signalSlice.name, () => {
 	};
 
 	describe('initialState', () => {
-		let state: SignalSlice<typeof initialState, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -36,7 +37,7 @@ describe(signalSlice.name, () => {
 		const testSource$ = new Subject<Partial<typeof initialState>>();
 		const testSource2$ = new Subject<Partial<typeof initialState>>();
 
-		let state: SignalSlice<typeof initialState, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -104,6 +105,45 @@ describe(signalSlice.name, () => {
 					},
 				});
 				expect(state.increaseAge$).toBeDefined();
+			});
+		});
+	});
+
+	describe('asyncReducers', () => {
+		it('should create action that updates signal asynchronously', () => {
+			TestBed.runInInjectionContext(() => {
+				const testAge = 35;
+
+				const state = signalSlice({
+					initialState,
+					asyncReducers: {
+						load: (state, $: Observable<void>) =>
+							$.pipe(
+								switchMap(() => of(testAge)),
+								map((age) => ({ age }))
+							),
+					},
+				});
+
+				state.load();
+				expect(state().age).toEqual(testAge);
+			});
+		});
+
+		it('should create action stream for reducer', () => {
+			TestBed.runInInjectionContext(() => {
+				const state = signalSlice({
+					initialState,
+					asyncReducers: {
+						load: (state, $: Observable<void>) =>
+							$.pipe(
+								switchMap(() => of(35)),
+								map((age) => ({ age }))
+							),
+					},
+				});
+
+				expect(state.load$).toBeDefined();
 			});
 		});
 	});

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -123,19 +123,19 @@ export function signalSlice<
 	for (const [key, reducer] of Object.entries(reducers as TReducers)) {
 		const subject = new Subject();
 
-		if (reducer.length === 2) {
-			const standardReducer = reducer as Reducer<
-				(typeof config)['initialState'],
-				any
-			>;
-			connect(state, subject, standardReducer);
-		} else {
+		try {
 			const sourceReducer = reducer as SourceReducer<
 				(typeof config)['initialState'],
 				any
 			>;
 
 			connect(state, sourceReducer(subject));
+		} catch (err) {
+			const standardReducer = reducer as Reducer<
+				(typeof config)['initialState'],
+				any
+			>;
+			connect(state, subject, standardReducer);
 		}
 
 		Object.defineProperties(readonlyState, {

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -169,11 +169,7 @@ export function signalSlice<
 	for (const [key, reducer] of Object.entries(reducers as TReducers)) {
 		const subject = new Subject();
 
-		connect(
-			state,
-			subject,
-			reducer(readonlyState(), subject) as Reducer<TSignalValue, any>
-		);
+		connect(state, subject, reducer);
 
 		Object.defineProperties(readonlyState, {
 			[key]: {

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -60,6 +60,10 @@ type ActionStreams<
 		: never;
 };
 
+type SourcesArray<TSignalValue> = Array<
+	Observable<PartialOrValue<TSignalValue>>
+>;
+
 export type SignalSlice<
 	TSignalValue,
 	TReducers extends NamedReducers<TSignalValue>,
@@ -79,18 +83,25 @@ export function signalSlice<
 	TEffects extends NamedEffects
 >(config: {
 	initialState: TSignalValue;
-	sources?: Array<Observable<PartialOrValue<TSignalValue>>>;
 	reducers?: TReducers;
 	selectors?: (state: Signal<TSignalValue>) => TSelectors;
 	effects?: (
 		state: SignalSlice<TSignalValue, TReducers, TSelectors, any>
 	) => TEffects;
+	sources?:
+		| SourcesArray<TSignalValue>
+		| ((
+				state: SignalSlice<TSignalValue, any, TSelectors, TEffects>
+		  ) => SourcesArray<TSignalValue>);
 }): SignalSlice<TSignalValue, TReducers, TSelectors, TEffects> {
 	const destroyRef = inject(DestroyRef);
 
 	const {
 		initialState,
-		sources = [],
+		sources = (() => ({})) as unknown as Exclude<
+			(typeof config)['sources'],
+			undefined
+		>,
 		reducers = {},
 		selectors = (() => ({})) as unknown as Exclude<
 			(typeof config)['selectors'],
@@ -103,10 +114,6 @@ export function signalSlice<
 	} = config;
 
 	const state = signal(initialState);
-
-	for (const source of sources) {
-		connect(state, source);
-	}
 
 	const readonlyState = state.asReadonly();
 	const subs: Subject<unknown>[] = [];
@@ -159,6 +166,16 @@ export function signalSlice<
 				}
 			}),
 		});
+	}
+
+	if (Array.isArray(sources)) {
+		for (const source of sources) {
+			connect(state, source);
+		}
+	} else {
+		for (const source of sources(slice)) {
+			connect(state, source);
+		}
 	}
 
 	destroyRef.onDestroy(() => {


### PR DESCRIPTION
This is a draft implementation that allows optionally supplying sources as a function that can utilise the current state and return an array of sources.

This addresses what I think is a fundamental problem with the current implementation and is highlighted by this use case from @justinrassier on Twitter: https://twitter.com/justinrassier/status/1722619039787446438 - I've also already run into this issue for error handling

Actions can be created by defining reducers, but if you want a source to be able to utilise an action you have to define one separately outside of `signalSlice` (e.g. as in the example above where a separate `load$` action is created with a subject).

This change would allow (optionally) supplying a function instead of an array of sources directly:

```ts
  state = signalSlice({
    initialState: this.initialState,
    sources: (state) => [
      state.manualLoad$.pipe(switchMap(() => this.sources$)),
    ],
    reducers: {
      manualLoad: () => ({}),
    },
  });
```

This allows creating the action inside of `signalSlice` but still also allows it to be utilised by `sources`. This particular example waits for the `manualLoad` action to be triggered before actually loading from the sources.

The current implementation in this PR works, but the typing is broken. I am opening this draft PR to investigate whether it is possible to type this API or whether we can arrive at an alternative solution.