### PR TITLE
feat(signal-slice): allow supplying source as a function that accepts state signal

### DIFF
--- a/docs/src/content/docs/utilities/Signals/signal-slice.md
+++ b/docs/src/content/docs/utilities/Signals/signal-slice.md
@@ -56,6 +56,25 @@ state = signalSlice({
 
 The `source` should be mapped to a partial of the `initialState`. In the example above, when the source emits it will update both the `checklists` and the `loaded` properties in the state signal.
 
+If you need to utilise the current state in a source, instead of supplying the
+observable directly as a source you can supply a function that accepts the state
+signal and returns the source:
+
+```ts
+state = signalSlice({
+	initialState: this.initialState,
+	sources: [
+		this.loadChecklists$,
+		(state) =>
+			this.newMessage$.pipe(
+				map((newMessage) => ({
+					messages: [...state().messages, newMessage],
+				}))
+			),
+	],
+});
+```
+
 ## Reducers and Actions
 
 Another way to update the state is through `reducers` and `actions`. This is good for situations where you need to manually/imperatively trigger some action, and then use the current state in some way in order to calculate the new state.

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -74,6 +74,28 @@ describe(signalSlice.name, () => {
 			expect(state().user.firstName).toEqual(testUpdate.user.firstName);
 			expect(state().age).toEqual(testUpdate2.age);
 		});
+
+		it('should allow supplying function that takes state signal', () => {
+			const ageSource$ = new Subject<number>();
+
+			TestBed.runInInjectionContext(() => {
+				state = signalSlice({
+					initialState,
+					sources: [
+						testSource$,
+						(state) =>
+							ageSource$.pipe(
+								map((incrementAge) => ({ age: state().age + incrementAge }))
+							),
+					],
+				});
+			});
+
+			const incrementAge = 5;
+			ageSource$.next(incrementAge);
+
+			expect(state().age).toEqual(initialState.age + incrementAge);
+		});
 	});
 
 	describe('reducers', () => {


### PR DESCRIPTION
This adds the ability to supply a source as a function that accepts the state signal - this allows a source to access the current state if necessary, e.g:

```ts
state = signalSlice({
	initialState: this.initialState,
	sources: [
		this.loadChecklists$,
		(state) =>
			this.newMessage$.pipe(
				map((newMessage) => ({
					messages: [...state().messages, newMessage],
				}))
			),
	],
});
```