### PR TITLE
feat: add 404 page

### DIFF
--- a/docs/src/content/docs/404.md
+++ b/docs/src/content/docs/404.md
@@ -1,0 +1,13 @@
+---
+title: '404'
+template: splash
+editUrl: false
+hero:
+  title: '404'
+  tagline: Page not found. Check the URL or try using the search bar.
+  actions:
+    - text: Go to Homepage
+      link: /
+      icon: right-arrow
+      variant: primary
+---


### PR DESCRIPTION
In case user visits invalid URL, they should have a prominent way to go back to homepage.


Current behavior when opening not existing page:
<img width="1427" alt="image" src="https://github.com/nartc/ngxtension-platform/assets/20491952/70846c81-b01a-49b1-a061-c1784a3790ac">


After adding 404 page:
<img width="1406" alt="image" src="https://github.com/nartc/ngxtension-platform/assets/20491952/2d2a80d7-908e-4b8b-b234-f7732138e3ac">

