### PR TITLE
feat(signal-slice): add actionEffects config

### DIFF
--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -305,6 +305,30 @@ describe(signalSlice.name, () => {
 		});
 	});
 
+	describe('actionEffects', () => {
+		it('should create effects for named actionEeffects', () => {
+			TestBed.runInInjectionContext(() => {
+				const testFn = jest.fn();
+
+				const state = signalSlice({
+					initialState,
+					reducers: {
+						increaseAge: (state) => ({ age: state.age + 1 }),
+					},
+					actionEffects: (state) => ({
+						increaseAge$: (val) => {
+							testFn(val.age);
+						},
+					}),
+				});
+
+				state.increaseAge();
+
+				expect(testFn).toHaveBeenCalledWith(initialState.age + 1);
+			});
+		});
+	});
+
 	describe('effects', () => {
 		it('should create effects for named effects', () => {
 			TestBed.runInInjectionContext(() => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -358,6 +358,84 @@ describe(signalSlice.name, () => {
 				expect(testFn).toHaveBeenCalled();
 			});
 		});
+
+		it('should supply appropriate values on action', () => {
+			TestBed.runInInjectionContext(() => {
+				const testFn = jest.fn();
+				const testPayload = 'a';
+				const age = 20;
+
+				const state = signalSlice({
+					initialState,
+					actionSources: {
+						test: (state, $: Observable<string>) =>
+							$.pipe(
+								map(() => ({
+									age,
+								}))
+							),
+					},
+					actionEffects: () => ({
+						test: (action) => {
+							testFn({
+								name: action.name,
+								payload: action.payload,
+								value: action.value,
+								err: action.err,
+							});
+						},
+					}),
+				});
+
+				state.test(testPayload);
+
+				expect(testFn).toHaveBeenCalledWith({
+					name: 'test',
+					payload: testPayload,
+					value: { age },
+					err: undefined,
+				});
+			});
+		});
+
+		it('should supply appropriate values to action on error', () => {
+			TestBed.runInInjectionContext(() => {
+				const testFn = jest.fn();
+				const testPayload = 'a';
+				const error = new Error('oops');
+
+				const state = signalSlice({
+					initialState,
+					actionSources: {
+						test: (state, $: Observable<string>) =>
+							$.pipe(
+								map(() => {
+									throw error;
+								})
+							),
+					},
+					actionEffects: () => ({
+						test: (action) => {
+							testFn({
+								name: action.name,
+								payload: action.payload,
+								value: action.value,
+								err: action.err,
+							});
+						},
+					}),
+				});
+
+				state.test(testPayload);
+
+				expect(testFn).toHaveBeenCalledWith({
+					name: 'test',
+					payload: testPayload,
+					value: undefined,
+					err: error,
+				});
+			});
+		});
 	});
 
 	describe('effects', () => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -306,7 +306,7 @@ describe(signalSlice.name, () => {
 	});
 
 	describe('actionEffects', () => {
-		it.only('should create effects for named actionEffects', (done) => {
+		it('should create effects for named actionEffects', (done) => {
 			TestBed.runInInjectionContext(() => {
 				const state = signalSlice({
 					initialState,

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -318,7 +318,7 @@ describe(signalSlice.name, () => {
 							$.pipe(map((amount) => ({ age: state().age + amount }))),
 					},
 					actionEffects: (state) => ({
-						increaseAge$: (val) => {
+						increaseAge: (val) => {
 							testFn(state().age);
 							testFn(val);
 						},

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -15,7 +15,7 @@ describe(signalSlice.name, () => {
 	};
 
 	describe('initialState', () => {
-		let state: SignalSlice<typeof initialState, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -38,7 +38,7 @@ describe(signalSlice.name, () => {
 		const testSource$ = new Subject<Partial<typeof initialState>>();
 		const testSource2$ = new Subject<Partial<typeof initialState>>();
 
-		let state: SignalSlice<typeof initialState, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -306,25 +306,29 @@ describe(signalSlice.name, () => {
 	});
 
 	describe('actionEffects', () => {
-		it('should create effects for named actionEeffects', () => {
+		it('should create effects for named actionEffects', () => {
 			TestBed.runInInjectionContext(() => {
 				const testFn = jest.fn();
+				const increaseAmount = 5;
 
 				const state = signalSlice({
 					initialState,
-					reducers: {
-						increaseAge: (state) => ({ age: state.age + 1 }),
+					actionSources: {
+						increaseAge: (state, $: Observable<number>) =>
+							$.pipe(map((amount) => ({ age: state().age + amount }))),
 					},
 					actionEffects: (state) => ({
 						increaseAge$: (val) => {
-							testFn(val.age);
+							testFn(state().age);
+							testFn(val);
 						},
 					}),
 				});
 
-				state.increaseAge();
+				state.increaseAge(increaseAmount);
 
-				expect(testFn).toHaveBeenCalledWith(initialState.age + 1);
+				expect(testFn).toHaveBeenCalledWith(initialState.age + increaseAmount);
+				expect(testFn).toHaveBeenCalledWith(increaseAmount);
 			});
 		});
 	});

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -317,9 +317,9 @@ describe(signalSlice.name, () => {
 								map((age) => ({ age }))
 							),
 					},
-					actionEffects: () => ({
-						load: (state) => {
-							expect(state.age).toEqual(35);
+					actionEffects: (state) => ({
+						load: () => {
+							expect(state().age).toEqual(35);
 							done();
 						},
 					}),

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -306,29 +306,27 @@ describe(signalSlice.name, () => {
 	});
 
 	describe('actionEffects', () => {
-		it('should create effects for named actionEffects', () => {
+		it.only('should create effects for named actionEffects', (done) => {
 			TestBed.runInInjectionContext(() => {
-				const testFn = jest.fn();
-				const increaseAmount = 5;
-
 				const state = signalSlice({
 					initialState,
 					actionSources: {
-						increaseAge: (state, $: Observable<number>) =>
-							$.pipe(map((amount) => ({ age: state().age + amount }))),
+						load: (_state, $: Observable<void>) =>
+							$.pipe(
+								switchMap(() => of(35)),
+								map((age) => ({ age }))
+							),
 					},
-					actionEffects: (state) => ({
-						increaseAge: (val) => {
-							testFn(state().age);
-							testFn(val);
+					actionEffects: () => ({
+						load: (state) => {
+							expect(state.age).toEqual(35);
+							done();
 						},
 					}),
 				});
 
-				state.increaseAge(increaseAmount);
-
-				expect(testFn).toHaveBeenCalledWith(initialState.age + increaseAmount);
-				expect(testFn).toHaveBeenCalledWith(increaseAmount);
+				state.load();
+				TestBed.flushEffects();
 			});
 		});
 	});

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -311,6 +311,7 @@ describe(signalSlice.name, () => {
 				const state = signalSlice({
 					initialState,
 					actionSources: {
+						test: (_state, $: Observable<void>) => $.pipe(map(() => ({}))),
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -46,9 +46,9 @@ type ActionEffects<
 		TSignalValue,
 		NamedActionSources<TSignalValue>
 	>
-> = {
+> = Partial<{
 	[K in keyof TActionEffects]: void;
-};
+}>;
 
 type Action<TSignalValue, TValue> = TValue extends [void]
 	? () => Promise<TSignalValue>
@@ -96,9 +96,9 @@ type ActionStreams<
 type NamedActionEffects<
 	TSignalValue,
 	TActionSources extends NamedActionSources<TSignalValue>
-> = {
+> = Partial<{
 	[K in keyof TActionSources]: () => void;
-};
+}>;
 
 export type Source<TSignalValue> = Observable<PartialOrValue<TSignalValue>>;
 

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -169,6 +169,10 @@ export function signalSlice<
 			(typeof config)['effects'],
 			undefined
 		>,
+		actionEffects = (() => ({})) as unknown as Exclude<
+			(typeof config)['actionEffects'],
+			undefined
+		>,
 	} = config;
 
 	const state = signal(initialState);
@@ -241,6 +245,20 @@ export function signalSlice<
 				}
 			}),
 		});
+	}
+
+	for (const [key, namedActionEffect] of Object.entries(actionEffects(slice))) {
+		const actionStream$ = slice[key];
+
+		if (isObservable(actionStream$)) {
+			console.log('setting up', key);
+			console.log(actionStream$);
+			actionStream$.subscribe((val) => {
+				console.log(val);
+				console.log('yo');
+			});
+			actionStream$.subscribe(namedActionEffect);
+		}
 	}
 
 	destroyRef.onDestroy(() => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { connect, type PartialOrValue, type Reducer } from 'ngxtension/connect';
-import { Subject, isObservable, take, type Observable } from 'rxjs';
+import { Subject, isObservable, share, take, type Observable } from 'rxjs';
 
 type NamedActionSources<TSignalValue> = {
 	[actionName: string]:
@@ -218,7 +218,8 @@ export function signalSlice<
 		} else {
 			const subject = new Subject();
 			const observable = actionSource(readonlyState, subject);
-			connect(state, observable);
+			const sharedObservable = observable.pipe(share());
+			connect(state, sharedObservable);
 			addReducerProperties(
 				readonlyState,
 				state$,
@@ -227,7 +228,7 @@ export function signalSlice<
 				subject,
 				subs,
 				effectTrigger,
-				observable
+				sharedObservable
 			);
 		}
 

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -251,12 +251,6 @@ export function signalSlice<
 		const actionStream$ = slice[key];
 
 		if (isObservable(actionStream$)) {
-			console.log('setting up', key);
-			console.log(actionStream$);
-			actionStream$.subscribe((val) => {
-				console.log(val);
-				console.log('yo');
-			});
 			actionStream$.subscribe(namedActionEffect);
 		}
 	}


### PR DESCRIPTION
EDIT: The implementation of this has changed quite a bit since I did it initially so I've updated this comment to reflect that.

There might still be a bit of tweaking to do here (I haven't been able to properly type action.payload but all the other properties are fine), and I will need to write some docs, but it's at a state where it would be great to get some feedback. It works as is, I'm just not 100% sure on the API.

The initial motivation for this was an example from @nartc attempting to implement Real World app and running into an issue where an `actionSource` would need to run and once that completed a side effect (navigation) would need to occur with a dynamic route.

Currently with signalSlice, the primary way to execute effects is by reacting to a state change, but it seems useful and necessary to run side effects for streams too.

This PR contains an implementation to add `actionEffects`, generally they work like this (the actionEffect will be triggered when the source for the relevant action emits):

```ts
  state = signalSlice({
    initialState: this.initialState,
    sources: [this.sources$],
    actionSources: {
      login: (state, action$: Observable<string>) =>
        action$.pipe(
          switchMap(() => this.getTemporalUser()),
          map(() => ({}))
        ),
    },
    actionEffects: () => ({
      login: (action) => {
        console.log(action.name); // the name of the action triggered
        console.log(action.payload); // the value the action was called with
        console.log(action.value); // the value the source emitted with (if successful, undefined otherwise)
        console.log(action.err); // the error the source emitted (if errored, undefined otherwise)
      },
    }),
  });
```

This should solve the use case faced in Real World app:

```ts
  state = signalSlice({
    initialState: this.initialState,
    sources: [this.sources$],
    actionSources: {
      refresh: (state, action$: Observable<string[]>) =>
        action$.pipe(
          switchMap(() => doWhatever()),
          map(() => ({}))
        ),
    },
    actionEffects: () => ({
      refresh: (action) => {
        // navigate using params from action.payload
      },
    }),
  });
```

`actionEffects` are also passed the signal slice, so you could trigger more actions within actionEffects:

```ts
    actionEffects: (state) => ({
      someAction: (action) => {
        state.someOtherAction();
      },
    }),
```

**Other considerations**

* I've included `action.name` in the action data as I am intending to investigate adding support for an "all actions" stream, e.g. an action stream that will be triggered when any action is triggered. The plan is to allow creating an actionEffect that could react to this all actions stream, and being able to identify the action by name would be used - If I end up doing this it will be in a separate PR
* The standard `effects` config still exists which uses standard signal effects to react to signal state changes. I'm not sure if this is confusing or if its even really necessary to have this config option at all. Renaming `effects` to `signalEffects` or `stateEffects` might also be an option, or we could just leave it as is - not sure