### PR TITLE
docs: fix computedFrom example with injector

### DIFF
--- a/docs/src/content/docs/utilities/Signals/computed-from.md
+++ b/docs/src/content/docs/utilities/Signals/computed-from.md
@@ -226,7 +226,7 @@ export class MyComponent {
 				switchMap(([page, filters]) => this.dataService.getUserData(this.userId, page, filters)),
 				startWith([] as string[]) // change the initial value
 			),
-			this.injector // 👈 pass the injector as the third argument
+			{ injector: this.injector } // 👈 pass the injector in the options object
 		);
 	}
 }


### PR DESCRIPTION
This PR fixes [Issue 159](https://github.com/nartc/ngxtension-platform/issues/159).

Updates the docs at "[computedFrom - Use it outside of an injection](https://ngxtension.netlify.app/utilities/signals/computed-from/#5-use-it-outside-of-an-injection-context)" with an example that reflects the real usage of the function. 