### PR TITLE
feat: add collection for contributors

### DIFF
--- a/docs/src/components/Content.astro
+++ b/docs/src/components/Content.astro
@@ -1,12 +1,14 @@
 ---
 import Default from '@astrojs/starlight/components/MarkdownContent.astro';
 import type { Props } from '@astrojs/starlight/props';
+import { getEntry } from 'astro:content';
+import Contributor from './Contributor.astro';
 
-const {contributor} = Astro.props.entry.data;
+const contributor = Astro.props.entry.data.contributor ? await getEntry(Astro.props.entry.data.contributor) : null;
 
 ---
 
-{ contributor && <p class="contributor">Created by {contributor}</p> }
+{ contributor && <Contributor {...contributor.data}/> }
 
 <Default {...Astro.props}><slot /></Default>
 

--- a/docs/src/components/Contributor.astro
+++ b/docs/src/components/Contributor.astro
@@ -1,0 +1,41 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+
+interface Props {
+	name: string;
+	twitter?: string;
+    linkedin?: string;
+    github?: string;
+}
+
+const { name, twitter, linkedin, github } = Astro.props;
+
+---
+
+<p class="contributor">
+    Created by {name}
+    {twitter && <a href={twitter}><Icon class='icon' name="twitter" size="0.75rem" /></a>}
+    {linkedin && <a href={linkedin}><Icon class='icon' name="linkedin" size="0.75rem" /></a>}
+    {github && <a href={github}><Icon class='icon' name="github" size="0.75rem" /></a>}
+
+</p>
+
+<style>
+    .contributor {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        margin-top: -1rem;
+        font-size: var(--sl-text-xs);
+        color: var(--sl-color-gray-3);
+    }
+    
+    .icon {
+        vertical-align: middle;
+        color: var(--sl-color-gray-3);
+
+        &:hover {
+            color: var(--sl-color-accent-high)
+        }
+    }
+</style>

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -1,13 +1,28 @@
 import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, reference, z } from 'astro:content';
+
+const contributors = defineCollection({
+	type: 'data',
+	schema: z.object({
+		name: z.string(),
+		twitter: z.string().url().optional(),
+		linkedin: z.string().url().optional(),
+		github: z.string().url().optional(),
+	}),
+});
+
+const docs = defineCollection({
+	schema: (ctx) =>
+		docsSchema()(ctx).extend({
+			badge: z.enum(['stable', 'unstable', 'experimental']).optional(),
+			contributor: reference('contributors').optional(),
+		}),
+});
+
+const i18n = defineCollection({ type: 'data', schema: i18nSchema() });
 
 export const collections = {
-	docs: defineCollection({
-		schema: (ctx) =>
-			docsSchema()(ctx).extend({
-				badge: z.enum(['stable', 'unstable', 'experimental']).optional(),
-				contributor: z.string().optional(),
-			}),
-	}),
-	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
+	docs: docs,
+	i18n: i18n,
+	contributors: contributors,
 };

--- a/docs/src/content/contributors/thomas-laforge.json
+++ b/docs/src/content/contributors/thomas-laforge.json
@@ -1,0 +1,6 @@
+{
+	"name": "Thomas Laforge",
+	"twitter": "https://twitter.com/laforge_toma",
+	"linkedin": "https://www.linkedin.com/in/thomas-laforge-2b05a945/",
+	"github": "https://github.com/tomalaforge"
+}

--- a/docs/src/content/docs/utilities/Operators/filter-array.md
+++ b/docs/src/content/docs/utilities/Operators/filter-array.md
@@ -2,7 +2,7 @@
 title: filterArray
 description: An RxJS operator to simplify the process of filtering arrays within an Observable stream.
 badge: stable
-contributor: Thomas Laforge
+contributor: thomas-laforge
 ---
 
 ## Import

--- a/docs/src/content/docs/utilities/Operators/filter-nil.md
+++ b/docs/src/content/docs/utilities/Operators/filter-nil.md
@@ -2,7 +2,7 @@
 title: filterNil
 description: An RxJS operator designed to filter out `undefined` and `null` values from an Observable stream, returning a strongly-typed value.
 badge: stable
-contributor: Thomas Laforge
+contributor: thomas-laforge
 ---
 
 ## Import

--- a/docs/src/content/docs/utilities/Operators/map-array.md
+++ b/docs/src/content/docs/utilities/Operators/map-array.md
@@ -2,7 +2,7 @@
 title: mapArray
 description: An RxJS operator designed to apply a map function to an array within an Observable stream, simplifying array transformations.
 badge: stable
-contributor: Thomas Laforge
+contributor: thomas-laforge
 ---
 
 ## Import


### PR DESCRIPTION
To follow up on the contributor button and from the idea of @ajitzero, I added a new collection to collect contributors data where we can add a link to twitter, github, linkedin. Other link can be added. 