### PR TITLE
fix(signal-slice): Do not allow optional properties in signalSlice

### DIFF
--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -33,7 +33,7 @@ describe(signalSlice.name, () => {
 			expect(state.age()).toEqual(initialState.age);
 		});
 
-		it('optional properties are not allowed in initial state', () => {
+		it('should not allow optional properties in initial state', () => {
 			// @ts-expect-error
 			signalSlice<{ optional?: string }, any, any, any>({
 				initialState: { optional: 'test' },

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -32,6 +32,13 @@ describe(signalSlice.name, () => {
 		it('should create default selectors', () => {
 			expect(state.age()).toEqual(initialState.age);
 		});
+
+		it('optional properties are not allowed in initial state', () => {
+			// @ts-expect-error
+			signalSlice<{ optional?: string }, any, any, any>({
+				initialState: { optional: 'test' },
+			});
+		});
 	});
 
 	describe('sources', () => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -33,8 +33,8 @@ describe(signalSlice.name, () => {
 			expect(state.age()).toEqual(initialState.age);
 		});
 
-		it('should not allow optional properties in initial state', () => {
-			// @ts-expect-error
+		it('should not accept optional properties in initial state', () => {
+			// @ts-expect-error: Testing that signalSlice should not accept an optional property in its initial state
 			signalSlice<{ optional?: string }, any, any, any>({
 				initialState: { optional: 'test' },
 			});

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -11,6 +11,10 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { connect, type PartialOrValue, type Reducer } from 'ngxtension/connect';
 import { Subject, isObservable, take, type Observable } from 'rxjs';
 
+type NoOptionalProperties<T> = {
+	[P in keyof T]-?: T[P];
+};
+
 type NamedActionSources<TSignalValue> = {
 	[actionName: string]:
 		| Subject<any>
@@ -86,7 +90,7 @@ type ActionStreams<
 export type Source<TSignalValue> = Observable<PartialOrValue<TSignalValue>>;
 
 export type SignalSlice<
-	TSignalValue,
+	TSignalValue extends NoOptionalProperties<TSignalValue>,
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects
@@ -98,7 +102,7 @@ export type SignalSlice<
 	ActionStreams<TSignalValue, TActionSources>;
 
 export function signalSlice<
-	TSignalValue,
+	TSignalValue extends NoOptionalProperties<TSignalValue>,
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects


### PR DESCRIPTION
Optional properties in the initial state pose an issue with selectors, this PR forces a user to set it as undefined instead.

### With `?:`
![image](https://github.com/nartc/ngxtension-platform/assets/15246162/34be77c4-1ffa-4f23-9c4d-c9e967170a5c)

### With `| undefined`
![image](https://github.com/nartc/ngxtension-platform/assets/15246162/cea1d44b-2aac-4538-85df-84a34b5c4334)

Issue explaining in detail: https://github.com/nartc/ngxtension-platform/issues/176