### PR TITLE
feat(docs): add internationalization to docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,11 @@
 import starlight from '@astrojs/starlight';
 import { defineConfig } from 'astro/config';
 
+export const locales = {
+	root: { label: 'English', lang: 'en' },
+	es: { label: 'Español', lang: 'es' },
+};
+
 // https://astro.build/config
 export default defineConfig({
 	integrations: [
@@ -20,15 +25,32 @@ export default defineConfig({
 				{
 					label: 'Getting Started',
 					autogenerate: { directory: 'getting-started' },
+					translations: {
+						es: 'Inicio',
+					},
 				},
 				{
 					label: 'Utilities',
 					autogenerate: { directory: 'utilities' },
+					translations: {
+						es: 'Utilidades',
+					},
 				},
 			],
 			components: {
 				PageTitle: './src/components/PageTitle.astro',
 				MarkdownContent: './src/components/Content.astro',
+			},
+			defaultLocale: 'root',
+			locales: {
+				root: {
+					label: 'English',
+					lang: 'en',
+				},
+				es: {
+					label: 'Español',
+					lang: 'es',
+				},
 			},
 		}),
 	],

--- a/docs/src/content/docs/es/getting-started/installation.mdx
+++ b/docs/src/content/docs/es/getting-started/installation.mdx
@@ -1,0 +1,62 @@
+---
+title: Instalación
+description: Cómo agregar ngxtension a tu proyecto
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+### Automático
+
+`ngxtension` viene con un esquematico/generador de inicialización tanto para Angular CLI como para [Nx](https://nx.dev).
+
+El esquematico/generador agrega `ngxtension` como una dependencia al proyecto y activa `skipLibCheck` para asegurar que los typings de librerias externas no fallen la rigurosidad del proyecto.
+
+#### Angular CLI
+
+```shell title="Adding ngxtension"
+ng add ngxtension
+```
+
+#### Nx CLI
+
+<Tabs>
+	<TabItem label="npm">
+
+```shell title="Instalando ngxtension"
+  npm install ngxtension
+```
+
+  </TabItem>
+	<TabItem label="yarn">
+
+```shell title="Instalando ngxtension"
+yarn add ngxtension
+```
+
+  </TabItem>
+	<TabItem label="pnpm">
+
+```shell title="Instalando ngxtension"
+pnpm install ngxtension
+```
+
+  </TabItem>
+</Tabs>
+
+Luego invoca el generador `ngxtension:init`
+
+```shell title="Invocar el init generator"
+nx g ngxtension:init
+```
+
+### Manual
+
+Instala `ngxtension` utilizando el comando anterior y luego activa `skipLibCheck: true` en el archivo tsconfig.json `root` del proyecto.
+
+> Para Nx, podría ser `tsconfig.base.json`
+
+## Matriz de Compatibilidad
+
+WIP

--- a/docs/src/content/docs/es/getting-started/introduction.md
+++ b/docs/src/content/docs/es/getting-started/introduction.md
@@ -1,0 +1,15 @@
+---
+title: Introducción
+description: ¿Qué es ngxtension?
+sidebar:
+  order: 1
+---
+
+`ngxtension` es una librería de utilidades para [Angular](https://angular.io). Consiste en una variedad de utilidades que facilitan el desarrollo de Angular y lo hacen más consistente.
+
+El proyecto fue iniciado por [Chau](https://github.com/nartc) junto con [Enea](https://twitter.com/Enea_Jahollari) y es completamente [de código abierto](https://github.com/nartc/ngxtension-platform). Agradecemos las contribuciones de todo tipo. Si tienes un problema o una idea, por favor [háznoslo saber](https://github.com/nartc/ngxtension-platform/issues/new).
+¿Te encuentras agregando algo una y otra vez a cada proyecto de Angular? Eso es algo que queremos tener en `ngxtension`. Nuestra intención es que `ngxtension` sea "_todo vale_", pero también con consideración cuidadosa y código Angular de calidad para que `ngxtension` pueda convertirse en una tienda única para todos los desarrolladores de Angular.
+
+## Consideración del tamaño del paquete(bundle)
+
+La biblioteca está compuesta enteramente por [Secondary Entry Point](https://angular.io/guide/angular-package-format#entrypoints-and-code-splitting). Aunque enviamos `ngxtension` como un solo paquete (para que sea fácil de instalar para los consumidores), el pipeline de construcción de Angular debe manejar adecuadamente la división de código y el tree-shaking para todos los puntos de entrada que `ngxtension` incluye.

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Bienvenido a ngxtension
+template: splash
+hero:
+  tagline: Una colección de utilidades para Angular.
+  image:
+    file: ../../../../public/logo.svg
+    alt: ngxtension logo
+
+  actions:
+    - text: Inicio
+      link: /es/getting-started/introduction
+      icon: right-arrow
+      variant: primary
+    - text: Ver en GitHub
+      link: https://github.com/nartc/ngxtension-platform
+      icon: external
+---
+
+Documentation powered by [Starlight Astro](https://starlight.astro.build/).

--- a/docs/src/content/docs/es/utilities/Components/host-binding.md
+++ b/docs/src/content/docs/es/utilities/Components/host-binding.md
@@ -1,0 +1,48 @@
+---
+title: hostBinding
+description: ngxtension/host-binding
+badge: stable
+contributor: lucas-garcia
+---
+
+`hostBinding` es una función que devuelve una señal _writable_ o _readonly_ y vincula(bind) el valor que contiene esa señal a la propiedad del host que se pasa como primer argumento tal como `@HostBinding` lo haría.
+
+```ts
+import { hostBinding } from 'ngxtension/host-binding';
+```
+
+## Uso
+
+Con `@HostBinding` se puede vincular(bind) un color desde una propiedad de clase:
+
+```ts
+@Component({
+  standalone: true;
+  selector: 'my-component'
+  template: '...'
+})
+export class MyComponent {
+  @HostBinding('style.color') color = 'red';
+
+  updateColor(color: 'red' | 'blue') {
+    this.color = color;
+  }
+}
+```
+
+Con `hostBinding` ahora se puede vincular(bind) cualquier cosa como `@HostBinding` en señales de escritura o solo lectura:
+
+```ts
+@Component({
+  standalone: true;
+  selector: 'my-component'
+  template: '...'
+})
+export class MyComponent {
+  color = hostBinding('style.color', signal('red'));
+
+  updateColor(color: 'red' | 'blue') {
+    this.color.set(color);
+  }
+}
+```

--- a/docs/src/content/docs/es/utilities/Directives/click-outside.md
+++ b/docs/src/content/docs/es/utilities/Directives/click-outside.md
@@ -1,0 +1,35 @@
+---
+title: clickOutside
+description: An Angular directive that is used to detect clicks outside the element.
+badge: stable
+contributor: dale-nguyen
+---
+
+## Importa la directiva
+
+```ts
+import { ClickOutside } from 'ngxtension/click-outside';
+```
+
+## Uso
+
+### Básico
+
+Agrega la directiva `clickOutside` al elemento Angular.
+
+```ts
+@Component({
+	standalone: true,
+	template: `
+		<div (clickOutside)="close()"></div>
+	`,
+	imports: [ClickOutside],
+})
+class TestComponent {
+	close() {
+		// close logic
+	}
+}
+```
+
+Esto activará el método `close()` cuando el usuario haga clic fuera del elemento objetivo.

--- a/docs/src/content/docs/es/utilities/Directives/repeat.md
+++ b/docs/src/content/docs/es/utilities/Directives/repeat.md
@@ -1,0 +1,52 @@
+---
+title: repeat
+description: An Angular directive extending NgFor to allow iteration over a fixed number of iterations.
+badge: stable
+contributor: chau-tran
+---
+
+## Importa la directiva
+
+```ts
+import { Repeat } from 'ngxtension/repeat';
+```
+
+## Uso
+
+### Básico
+
+Utiliza la directiva `Repeat` como una extensión de `NgFor` de Angular para iterar sobre un número fijo de iteraciones. La [`TrackByFunction`](https://angular.io/api/core/TrackByFunction) se establece automáticamente para iterar de manera eficiente.
+
+```ts
+import { Component } from '@angular/core';
+import { Repeat } from 'ngxtension/repeat';
+
+@Component({
+	imports: [Repeat],
+	template: `
+		<ul>
+			<li *ngFor="let i; repeat: 3">{{ i }}</li>
+		</ul>
+	`,
+})
+export class App {}
+```
+
+Esto producirá el siguiente output:
+
+```html
+<!-- Output -->
+<!-- <li>0</li> -->
+<!-- <li>1</li> -->
+<!-- <li>2</li> -->
+```
+
+## API
+
+### Inputs
+
+- `n: number` - Un entero no negativo, que especifica el número de iteraciones.
+
+### Validación
+
+- Un error se lanza si el `input` es negativo o no es un entero.

--- a/docs/src/content/docs/es/utilities/Directives/resize.mdx
+++ b/docs/src/content/docs/es/utilities/Directives/resize.mdx
@@ -1,0 +1,109 @@
+---
+title: resize
+description: Una directiva y función de Angular para escuchar eventos de cambio de tamaño de elementos, lo que te permite responder dinámicamente a cambios en el tamaño de los elementos.
+badge: stable
+contributor: tomer
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+## Importa la directiva
+
+```ts
+import { NgxResize, injectResize } from 'ngxtension/resize';
+```
+
+El `resize` entry point expone 2 symbols:
+
+- `injectResize()`: un CIF que observa el evento de cambio de tamaño en el elemento Host del componente.
+- `NgxResize`: una directiva que puede observar el evento de cambio de tamaño de cualquier elemento al que esté adjunta.
+
+Ambos emiten el resultado del cambio de tamaño fuera de la [Zona Angular](https://angular.io/guide/zone) de forma predeterminada, pero ambos proporcionan una forma de configurar el comportamiento.
+
+## Uso
+
+### `injectResize`
+
+`injectResize` retorna un `Observable<ResizeResult>` (see [ResizeResult TBD]())
+
+```ts
+export class App {
+	resize$ = injectResize(); // Observable<ResizeResult>
+}
+```
+
+### `NgxResize`
+
+<Tabs>
+	<TabItem label="html">
+
+```html
+<div (ngxResize)="onResize($event)">
+	<!-- content -->
+</div>
+```
+
+  </TabItem>
+	<TabItem label="ts">
+
+```ts
+@Component({
+	imports: [NgxResize],
+	templateUrl: './app.html',
+})
+export class App {
+	onResize(event: ResizeResult) {
+		// runs outside of Angular Zone by default
+	}
+}
+```
+
+  </TabItem>
+</Tabs>
+
+Si no eres fan de `inject()`, también puedes usar `NgxResize` en el elemento Host aprovechando `hostDirectives`
+
+```ts
+@Component({
+	hostDirectives: [{ directive: NgxResize, outputs: ['ngxResize'] }],
+})
+export class App {
+	@HostListener('ngxResize', ['$event'])
+	onResize(event: ResizeResult) {
+		// listen for resize event from NgxResize
+	}
+}
+```
+
+### `ResizeOptions`
+
+Podemos pasar opciones específicas de `ResizeOptions` a ambas opciones de inyección y directiva.
+
+```ts
+injectResize(someOptions);
+```
+
+```html
+<div (ngxResize)="onResize($event)" [ngxResizeOptions]="someOptions">
+	<div></div>
+</div>
+```
+
+Para proveer `ResizeOptions` globalmente a la aplicación o a un subárbol de componentes (a través de `Route#providers`), podemos usar `provideResizeOptions()`
+
+```ts
+// Standalone
+bootstrapApplication(App, { providers: [provideResizeOptions(globalOptions)] });
+
+// AppModule
+@NgModule({
+	providers: [provideResizeOptions(globalOptions)],
+})
+export class AppModule {}
+
+// Route#provider (equivalent to Lazy-load modules)
+const route = {
+	path: 'some-path',
+	providers: [provideResizeOptions(subTreeGlobalOptions)],
+};
+```

--- a/docs/src/content/docs/es/utilities/Directives/trackby-id-prop.md
+++ b/docs/src/content/docs/es/utilities/Directives/trackby-id-prop.md
@@ -1,0 +1,69 @@
+---
+title: TrackById / TrackByProp
+descripción: Directivas de Angular que simplifican el uso de trackBy en *ngFor, eliminando la necesidad de métodos personalizados en componentes.
+badge: stable
+contributor: daniele-morosinotto
+---
+
+## Importa las directivas
+
+```ts
+import { TrackById, TrackByProp } from 'ngxtension/trackby-id-prop';
+```
+
+## Uso
+
+### TrackById
+
+Para objetos que tienen una propiedad `id`, utiliza `TrackById` para iterar de manera eficiente a través de ellos en `*ngFor`.
+
+```ts
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { TrackById } from 'ngxtension/trackby-id-prop';
+
+@Component({
+	selector: 'my-app',
+	imports: [TrackById],
+	template: `
+		<ul *ngFor="let item of arr; trackById">
+			<li>{{ item.name }}</li>
+		</ul>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class App {
+	public arr = [
+		{ id: 1, name: 'foo' },
+		{ id: 2, name: 'bar' },
+		{ id: 3, name: 'baz' },
+	];
+}
+```
+
+### TrackByProp
+
+Si necesitas especificar una propiedad diferente para el tracking, utiliza `TrackByProp`.
+
+```ts
+template: `
+	<p *ngFor="let item of arr; trackByProp: 'name'">
+		{{ item.name }} @{{ item.id }}
+	</p>
+`;
+```
+
+## API
+
+### Inputs para TrackById
+
+- `ngForOf: NgIterable<T>` - Un iterable que contiene objetos con una propiedad `id`.
+
+### Inputs para TrackByProp
+
+- `ngForOf: NgIterable<T>` - Un iterable de objetos.
+- `ngForTrackByProp: keyof T` - El nombre de la propiedad para trackear los objetos (obligatorio).
+
+### Validación
+
+- Para `TrackById`, un error es lanzado si los objetos del iterable no tienen una propiedad `id`.
+- Para `TrackByProp`, un error es lanzado si la propiedad especificada no existe en los objetos del iterable.

--- a/docs/src/content/docs/es/utilities/Forms/if-validator.md
+++ b/docs/src/content/docs/es/utilities/Forms/if-validator.md
@@ -1,0 +1,61 @@
+---
+title: ifValidator / ifAsyncValidator
+descripción: Funciones para cambiar dinámicamente la validación del Formulario Reactivo de Angular.
+badge: stable
+contributor: tomer
+---
+
+## Import
+
+```typescript
+import { ifValidator, ifAsyncValidator } from 'ngxtension/if-validator';
+```
+
+## Uso
+
+### ifValidator
+
+Usa `ifValidator` para aplicar validación condicional de formularios. Acepta una condición de callback y `ValidatorFn` o `ValidatorFn[]`.
+
+```typescript
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ifValidator } from 'ngxtension/if-validator';
+
+@Component({
+	selector: 'my-app',
+	imports: [CommonModule, ReactiveFormsModule],
+	template: `
+		<input [formControl]="form" />
+		<div>Is Form Valid: {{ form.valid }}</div>
+		<button (click)="changeCondition()">Change Form Condition</button>
+	`,
+})
+export class App {
+	public shouldValidate = true;
+	public form = new FormControl(
+		null,
+		ifValidator(() => this.shouldValidate, [Validators.required, Validators.email])
+	);
+
+	public changeCondition() {
+		this.shouldValidate = !this.shouldValidate;
+		this.form.updateValueAndValidity();
+	}
+}
+```
+
+### ifAsyncValidator
+
+Similar a `ifValidator` pero para validación asíncrona.
+
+## API
+
+### Inputs para ifValidator
+
+- `condition: (control: FormControl) => boolean` - Una función de callback para determinar si los validadores deben aplicarse.
+- `validatorFn: ValidatorFn | ValidatorFn[]` - La(s) función(es) de validación a usar.
+
+### Inputs para ifAsyncValidator
+
+- `condition: (control: FormControl) => boolean` - Una función de callback para determinar si los validadores asíncronos deben aplicarse.
+- `validatorFn: AsyncValidatorFn | AsyncValidatorFn[]` - La(s) función(es) de validación asíncrona a usar.

--- a/docs/src/content/docs/es/utilities/Gesture/gesture.mdx
+++ b/docs/src/content/docs/es/utilities/Gesture/gesture.mdx
@@ -1,0 +1,147 @@
+---
+title: Gesture
+description: ngxtension/gestures
+badge: stable
+contributor: chau-tran
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+## Uso
+
+Hay varias formas en que podemos utilizar el Gesture de `ngxtension/gestures`
+
+Los ejemplos muestran el uso de `NgxDrag`, para `DragGesture`, pero también se pueden aplicar a otros gestos.
+
+### Directiva
+
+```ts
+import { NgxDrag, type NgxInjectDrag } from 'ngxtension/gestures';
+```
+
+`NgxDrag` es una directiva que podemos usar para adjuntar en cualquier elemento para capturar los eventos de arrastre de ese elemento.
+
+<Tabs>
+	<TabItem label="html">
+
+```html
+<div class="draggable-box" (ngxDrag)="onDrag($event)">
+	<!-- content -->
+</div>
+```
+
+  </TabItem>
+	<TabItem label="ts">
+
+```ts
+@Component({
+	imports: [NgxDrag],
+	templateUrl: './app.html',
+})
+export class App {
+	onDrag(state: NgxInjectDrag['state']) {
+		// fire every time a drag event happens
+	}
+}
+```
+
+  </TabItem>
+</Tabs>
+
+#### Como `hostDirective`
+
+También podemos usar `NgxDrag` en un elemento Host aprovechando `hostDirectives`
+
+```ts
+@Component({
+	selector: 'app-draggable-box',
+	standalone: true,
+	hostDirectives: [{ directive: NgxDrag, outputs: ['ngxDrag'] }],
+	template: ``,
+})
+export class DraggableBox {
+	@HostListener('ngxDrag', ['$event'])
+	onDrag(state: NgxInjectDrag['state']) {
+		// fire every time a drag event happens
+	}
+}
+```
+
+### `injectDrag`
+
+Otra forma de habilitar Drag Gesture es usar el CIF `injectDrag`.
+
+```ts
+@Component({
+	selector: 'app-draggable-box',
+	standalone: true,
+	template: ``,
+})
+export class DraggableBox {
+	constructor() {
+		injectDrag((state) => {
+			// fire every time a drag event happens
+		});
+	}
+}
+```
+
+Con eso en mente, el verdadero poder de `injectDrag` es la facilidad de componer diferentes comportamientos encima de Drag Gesture.
+Por ejemplo, podemos tener un CIF que habilita Drag Gesture y devuelve una `Signal<Vector2>` que puede desencadenar otros efectos.
+
+```ts
+export function injectDragPosition() {
+	const position = signal<Vector2>([0, 0]);
+
+	injectDrag(({ offset }) => {
+		position.set(offset);
+	});
+
+	return position.asReadonly();
+}
+```
+
+## Configuración
+
+- Para `NgxDrag`, podemos proporcionar un objeto de configuración a través del input `[ngxDragConfig]`.
+- Para `injectDrag`, podemos proporcionar una configuración de `Signal<DragConfig>` (o una `Function` que devuelve `DragConfig`) en el segundo argumento
+
+```ts
+injectDrag(dragHandler, {
+	config: () => dragConfig,
+});
+```
+
+## Zone
+
+Drag Gesture está habilitado dentro de Zone por defecto.
+
+Para `NgxDrag`, podemos entrar en modo zoneless a través de la entrada `[ngxDragZoneless]`.
+Para `injectDrag`, podemos entrar en modo zonless a través de la opción `zoneless` en el segundo argumento
+
+```ts
+injectDrag(dragHandler, { zoneless: true });
+```
+
+### Con Global Zoneless
+
+Además, podemos permitir que todos los gestos en un cierto árbol de componentes opten automáticamente por el modo zoneless llamando a `provideZonelessGesture()`
+
+```ts
+// application wise
+bootstrapApplication(App, { providers: [provideZonelessGesture()] });
+
+// route provider
+const routes = [
+	{
+		path: '',
+		providers: [provideZonelessGesture()],
+	},
+];
+
+// component provider
+@Component({
+	providers: [provideZonelessGesture()],
+})
+export class MyComponent {}
+```

--- a/docs/src/content/docs/es/utilities/Gesture/intro.md
+++ b/docs/src/content/docs/es/utilities/Gesture/intro.md
@@ -1,0 +1,26 @@
+---
+title: 'Introducción'
+description: 'ngxtension/gestures'
+badge: stable
+contributor: chau-tran
+sidebar:
+  order: 1
+---
+
+`ngxtension/gestures` es una colección que te permite vincular (bind) a eventos de mouse y touch.
+
+- [x] Drag
+- [x] Move
+- [x] Hover
+- [x] Scroll
+- [x] Wheel
+- [x] Pinch
+- [ ] Multiple gestures
+
+### Comparación al Angular CDK
+
+[Angular CDK](https://cdk.angular.io) ofrece características como [Drag and Drop](https://material.angular.io/cdk/drag-drop/overview) y [Scrolling](https://material.angular.io/cdk/scrolling/overview),
+mientras que `ngxtension/gestures` se especializa en capturar gestos exclusivamente en elementos. En esencia, `ngxtension/gestures` opera desde una perspectiva más granular y de bajo nivel en comparación con Angular CDK.
+Su control detallado sobre los datos de los gestos te permite crear una amplia gama de interacciones y facilita la integración perfecta con bibliotecas de animación como [GSAP](https://greensock.com/gsap/).
+
+Para características específicas de arrastrar y soltar / desplazamiento virtual, todavía recomendamos utilizar Angular CDK.

--- a/docs/src/content/docs/es/utilities/Miscellaneous/singleton-proxy.md
+++ b/docs/src/content/docs/es/utilities/Miscellaneous/singleton-proxy.md
@@ -1,0 +1,24 @@
+---
+title: createSingletonProxy
+description: ngxtension/singleton-proxy
+badge: stable
+contributor: chau-tran
+---
+
+`createSingletonProxy` crea una instancia singleton de una clase dada cuando se accede a una propiedad dentro de ella, no antes.
+
+:::tip[Créditos]
+Crédito a [Poimandres](https://pmnd.rs/) por el código original en [R3F Rapier](https://github.com/pmndrs/react-three-rapier)
+:::
+
+## Uso
+
+```ts
+import { createSingletonProxy } from 'ngxtension/singleton-proxy';
+
+const { proxy: worldProxy, reset: resetWorld } = createSingletonProxy(() => new rapier.World([0, -9.81, 0]));
+
+worldProxy.gravity; // rapier.World() será creado hasta que llegue a este punto
+
+resetWorld(); // resetea la instancia
+```


### PR DESCRIPTION
- Adds internationalization to docs
- Adds translation in Spanish to the  landing page and the pages in the following folders:

1. Getting Started
2. Components pages
3. Directives 
4. Forms
5. Gesture
6. Miscellaneous

Addresses https://github.com/nartc/ngxtension-platform/issues/150
