### PR TITLE
feat(signal-slice): add lazySources

### DIFF
--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -1,7 +1,12 @@
-import { DestroyRef, Injector, type WritableSignal } from '@angular/core';
+import {
+	DestroyRef,
+	Injector,
+	untracked,
+	type WritableSignal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { assertInjector } from 'ngxtension/assert-injector';
-import { Subscription, isObservable, type Observable } from 'rxjs';
+import { isObservable, Subscription, type Observable } from 'rxjs';
 
 export type PartialOrValue<TValue> = TValue extends object
 	? Partial<TValue>
@@ -45,6 +50,7 @@ type ConnectedSignal<TSignalValue> = {
 export function connect<TSignalValue>(
 	signal: WritableSignal<TSignalValue>,
 	injectorOrDestroyRef?: Injector | DestroyRef,
+	useUntracked?: boolean,
 ): ConnectedSignal<TSignalValue>;
 export function connect<
 	TSignalValue,
@@ -53,22 +59,18 @@ export function connect<
 	signal: WritableSignal<TSignalValue>,
 	observable: Observable<TObservableValue>,
 	injectorOrDestroyRef?: Injector | DestroyRef,
+	useUntracked?: boolean,
 ): Subscription;
 export function connect<TSignalValue, TObservableValue>(
 	signal: WritableSignal<TSignalValue>,
 	observable: Observable<TObservableValue>,
 	reducer: Reducer<TSignalValue, TObservableValue>,
 	injectorOrDestroyRef?: Injector | DestroyRef,
+	useUntracked?: boolean,
 ): Subscription;
-export function connect(
-	signal: WritableSignal<unknown>,
-	...args: [
-		(Observable<unknown> | (Injector | DestroyRef))?,
-		(Reducer<unknown, unknown> | (Injector | DestroyRef))?,
-		(Injector | DestroyRef)?,
-	]
-) {
-	const [observable, reducer, injectorOrDestroyRef] = parseArgs(args);
+export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
+	const [observable, reducer, injectorOrDestroyRef, useUntracked] =
+		parseArgs(args);
 
 	if (observable) {
 		let destroyRef = null;
@@ -81,13 +83,21 @@ export function connect(
 		}
 
 		return observable.pipe(takeUntilDestroyed(destroyRef)).subscribe((x) => {
-			signal.update((prev) => {
-				if (typeof prev === 'object' && !Array.isArray(prev)) {
-					return { ...prev, ...((reducer?.(prev, x) || x) as object) };
-				}
+			const update = () => {
+				signal.update((prev) => {
+					if (typeof prev === 'object' && !Array.isArray(prev)) {
+						return { ...prev, ...((reducer?.(prev, x) || x) as object) };
+					}
 
-				return reducer?.(prev, x) || x;
-			});
+					return reducer?.(prev, x) || x;
+				});
+			};
+
+			if (useUntracked) {
+				untracked(update);
+			} else {
+				update();
+			}
 		});
 	}
 
@@ -103,7 +113,8 @@ export function connect(
 				connect(
 					signal,
 					...(args as any),
-					injectorOrDestroyRef,
+					injectorOrDestroyRef as any,
+					useUntracked,
 				) as unknown as Subscription,
 			);
 			return this;
@@ -113,44 +124,65 @@ export function connect(
 }
 
 function parseArgs(
-	args: [
-		(Observable<unknown> | (Injector | DestroyRef))?,
-		(Reducer<unknown, unknown> | (Injector | DestroyRef))?,
-		(Injector | DestroyRef)?,
-	],
+	args: any[],
 ): [
 	Observable<unknown> | null,
 	Reducer<unknown, unknown> | null,
 	Injector | DestroyRef | null,
+	boolean,
 ] {
-	if (args.length > 2) {
+	if (args.length > 3) {
 		return [
 			args[0] as Observable<unknown>,
 			args[1] as Reducer<unknown, unknown>,
 			args[2] as Injector | DestroyRef,
+			args[3] as boolean,
+		];
+	}
+
+	if (args.length === 3) {
+		if (typeof args[2] === 'boolean') {
+			return [
+				args[0] as Observable<unknown>,
+				null,
+				args[1] as Injector | DestroyRef,
+				args[2],
+			];
+		}
+
+		return [
+			args[0] as Observable<unknown>,
+			args[1] as Reducer<unknown, unknown>,
+			args[2] as Injector | DestroyRef,
+			false,
 		];
 	}
 
 	if (args.length === 2) {
-		const [arg, arg2] = args;
-		const parsedArgs: [
-			Observable<unknown>,
-			Reducer<unknown, unknown> | null,
-			Injector | DestroyRef | null,
-		] = [arg as Observable<unknown>, null, null];
-		if (typeof arg2 === 'function') {
-			parsedArgs[1] = arg2;
-		} else {
-			parsedArgs[2] = arg2 as Injector | DestroyRef;
+		if (typeof args[1] === 'boolean') {
+			return [null, null, args[0] as Injector | DestroyRef, args[1]];
 		}
 
-		return parsedArgs;
+		if (typeof args[1] === 'function') {
+			return [
+				args[0] as Observable<unknown>,
+				args[1] as Reducer<unknown, unknown>,
+				null,
+				false,
+			];
+		}
+
+		return [
+			args[0] as Observable<unknown>,
+			null,
+			args[1] as Injector | DestroyRef,
+			false,
+		];
 	}
 
-	const arg = args[0];
-	if (isObservable(arg)) {
-		return [arg, null, null];
+	if (isObservable(args[0])) {
+		return [args[0] as Observable<unknown>, null, null, false];
 	}
 
-	return [null, null, arg as Injector | DestroyRef];
+	return [null, null, args[0] as Injector | DestroyRef, false];
 }

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -123,6 +123,7 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 	} as ConnectedSignal<unknown>;
 }
 
+// TODO: there must be a way to parse the args more efficiently
 function parseArgs(
 	args: any[],
 ): [

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -114,7 +114,7 @@ describe(signalSlice.name, () => {
 			map(() => {
 				testFn();
 				return {};
-			})
+			}),
 		);
 
 		let state: SignalSlice<typeof initialState, any, any, any, any>;

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -108,6 +108,45 @@ describe(signalSlice.name, () => {
 		});
 	});
 
+	describe('lazySources', () => {
+		const testFn = jest.fn();
+		const testSource$ = of('test').pipe(
+			map(() => {
+				testFn();
+				return {};
+			})
+		);
+
+		let state: SignalSlice<typeof initialState, any, any, any, any>;
+
+		beforeEach(() => {
+			TestBed.runInInjectionContext(() => {
+				state = signalSlice({
+					initialState,
+					lazySources: [testSource$],
+				});
+			});
+		});
+
+		it('should be not connect lazy source initially', () => {
+			expect(testFn).not.toHaveBeenCalled();
+		});
+
+		it('should connect lazy source after selector is accessed', () => {
+			TestBed.runInInjectionContext(() => {
+				state.age();
+				expect(testFn).toHaveBeenCalled();
+			});
+		});
+
+		it('should connect lazy source after signal value is accessed', () => {
+			TestBed.runInInjectionContext(() => {
+				state.age();
+				expect(testFn).toHaveBeenCalled();
+			});
+		});
+	});
+
 	describe('actionSources', () => {
 		it('should create action that updates signal', () => {
 			TestBed.runInInjectionContext(() => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -133,17 +133,13 @@ describe(signalSlice.name, () => {
 		});
 
 		it('should connect lazy source after selector is accessed', () => {
-			TestBed.runInInjectionContext(() => {
-				state.age();
-				expect(testFn).toHaveBeenCalled();
-			});
+			state.age();
+			expect(testFn).toHaveBeenCalled();
 		});
 
 		it('should connect lazy source after signal value is accessed', () => {
-			TestBed.runInInjectionContext(() => {
-				state.age();
-				expect(testFn).toHaveBeenCalled();
-			});
+			state.age();
+			expect(testFn).toHaveBeenCalled();
 		});
 	});
 

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -1,5 +1,6 @@
 import {
 	DestroyRef,
+	Injector,
 	computed,
 	effect,
 	inject,
@@ -177,6 +178,7 @@ export function signalSlice<
 	TActionEffects
 > {
 	const destroyRef = inject(DestroyRef);
+	const injector = inject(Injector);
 
 	const {
 		initialState,
@@ -288,7 +290,7 @@ export function signalSlice<
 		get(target, property, receiver) {
 			if (!lazySourcesLoaded) {
 				lazySourcesLoaded = true;
-				connectSources(state, lazySources);
+				connectSources(state, lazySources, injector);
 			}
 
 			return Reflect.get(target, property, receiver);
@@ -298,13 +300,14 @@ export function signalSlice<
 
 function connectSources<TSignalValue>(
 	state: WritableSignal<TSignalValue>,
-	sources: SourceConfig<TSignalValue>
+	sources: SourceConfig<TSignalValue>,
+	injector?: Injector
 ) {
 	for (const source of sources) {
 		if (isObservable(source)) {
-			connect(state, source);
+			connect(state, source, injector);
 		} else {
-			connect(state, source(state.asReadonly()));
+			connect(state, source(state.asReadonly()), injector);
 		}
 	}
 }

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -290,7 +290,7 @@ export function signalSlice<
 		get(target, property, receiver) {
 			if (!lazySourcesLoaded) {
 				lazySourcesLoaded = true;
-				connectSources(state, lazySources, injector);
+				connectSources(state, lazySources, injector, true);
 			}
 
 			return Reflect.get(target, property, receiver);
@@ -301,13 +301,14 @@ export function signalSlice<
 function connectSources<TSignalValue>(
 	state: WritableSignal<TSignalValue>,
 	sources: SourceConfig<TSignalValue>,
-	injector?: Injector
+	injector?: Injector,
+	useUntracked = false,
 ) {
 	for (const source of sources) {
 		if (isObservable(source)) {
-			connect(state, source, injector);
+			connect(state, source, injector, useUntracked);
 		} else {
-			connect(state, source(state.asReadonly()), injector);
+			connect(state, source(state.asReadonly()), injector, useUntracked);
 		}
 	}
 }


### PR DESCRIPTION
EDIT: The note below has been resolved

NOTE: This is a draft PR due to one remaining issue and I'm not sure if it can be solved with this set up. I think the crux of the issue is that I am relying on a proxy to detect when the state object is accessed in order to trigger the `lazySources` to `connect`:

```ts
  return new Proxy(slice, {
    get(target, property, receiver) {
      if (!lazySourcesLoaded) {
        lazySourcesLoaded = true;
        connectSources(state, lazySources, injector);
      }

      return Reflect.get(target, property, receiver);
    },
  });
```

Although it still seems to work (the observable values are still set into the signal), it triggers the `SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT` error:

```
ERROR Error: NG0600: Writing to signals is not allowed in a `computed` or an `effect` by default. Use `allowSignalWrites` in the `CreateEffectOptions` to enable this inside effects.
```

---

This adds support for `lazySources` as discussed here: https://github.com/nartc/ngxtension-platform/issues/196

It allows specifying `sources` and `lazySources` in the config - both are identical but the `lazySources` will not be supplied to the `connect` function until the state object has been accessed.

I have left this undocumented for now, ideally would like to have it used a little first. I think I also need to do a full sweep through and improve the docs as a whole as well.