### PR TITLE
fix(signal-slice): add apply trap to proxy for loading lazySources when signal value accessed directly

### DIFF
--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -95,7 +95,7 @@ describe(signalSlice.name, () => {
 						testSource$,
 						(state) =>
 							ageSource$.pipe(
-								map((incrementAge) => ({ age: state().age + incrementAge })),
+								map((incrementAge) => ({ age: state().age + incrementAge }))
 							),
 					],
 				});
@@ -114,7 +114,7 @@ describe(signalSlice.name, () => {
 			map(() => {
 				testFn();
 				return {};
-			}),
+			})
 		);
 
 		let state: SignalSlice<typeof initialState, any, any, any, any>;
@@ -126,6 +126,8 @@ describe(signalSlice.name, () => {
 					lazySources: [testSource$],
 				});
 			});
+
+			jest.clearAllMocks();
 		});
 
 		it('should be not connect lazy source initially', () => {
@@ -138,7 +140,7 @@ describe(signalSlice.name, () => {
 		});
 
 		it('should connect lazy source after signal value is accessed', () => {
-			state.age();
+			state().age;
 			expect(testFn).toHaveBeenCalled();
 		});
 	});
@@ -243,7 +245,7 @@ describe(signalSlice.name, () => {
 						load: (state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(testAge)),
-								map((age) => ({ age })),
+								map((age) => ({ age }))
 							),
 					},
 				});
@@ -261,7 +263,7 @@ describe(signalSlice.name, () => {
 						load: (state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),
-								map((age) => ({ age })),
+								map((age) => ({ age }))
 							),
 					},
 				});
@@ -278,7 +280,7 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),
-								map((age) => ({ age })),
+								map((age) => ({ age }))
 							),
 					},
 				});
@@ -301,8 +303,8 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<number>) =>
 							$.pipe(
 								switchMap((age) =>
-									timer(500).pipe(map(() => ({ age: 35 + age }))),
-								),
+									timer(500).pipe(map(() => ({ age: 35 + age })))
+								)
 							),
 					},
 				});
@@ -359,7 +361,7 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),
-								map((age) => ({ age })),
+								map((age) => ({ age }))
 							),
 					},
 					actionEffects: (state) => ({
@@ -386,7 +388,7 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => block$),
-								map(() => ({})),
+								map(() => ({}))
 							),
 					},
 					actionEffects: () => ({
@@ -416,7 +418,7 @@ describe(signalSlice.name, () => {
 							$.pipe(
 								map(() => ({
 									age,
-								})),
+								}))
 							),
 					},
 					actionEffects: () => ({
@@ -455,7 +457,7 @@ describe(signalSlice.name, () => {
 							$.pipe(
 								map(() => {
 									throw error;
-								}),
+								})
 							),
 					},
 					actionEffects: () => ({

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -95,7 +95,7 @@ describe(signalSlice.name, () => {
 						testSource$,
 						(state) =>
 							ageSource$.pipe(
-								map((incrementAge) => ({ age: state().age + incrementAge }))
+								map((incrementAge) => ({ age: state().age + incrementAge })),
 							),
 					],
 				});
@@ -114,7 +114,7 @@ describe(signalSlice.name, () => {
 			map(() => {
 				testFn();
 				return {};
-			})
+			}),
 		);
 
 		let state: SignalSlice<typeof initialState, any, any, any, any>;
@@ -245,7 +245,7 @@ describe(signalSlice.name, () => {
 						load: (state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(testAge)),
-								map((age) => ({ age }))
+								map((age) => ({ age })),
 							),
 					},
 				});
@@ -263,7 +263,7 @@ describe(signalSlice.name, () => {
 						load: (state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),
-								map((age) => ({ age }))
+								map((age) => ({ age })),
 							),
 					},
 				});
@@ -280,7 +280,7 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),
-								map((age) => ({ age }))
+								map((age) => ({ age })),
 							),
 					},
 				});
@@ -303,8 +303,8 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<number>) =>
 							$.pipe(
 								switchMap((age) =>
-									timer(500).pipe(map(() => ({ age: 35 + age })))
-								)
+									timer(500).pipe(map(() => ({ age: 35 + age }))),
+								),
 							),
 					},
 				});
@@ -361,7 +361,7 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => of(35)),
-								map((age) => ({ age }))
+								map((age) => ({ age })),
 							),
 					},
 					actionEffects: (state) => ({
@@ -388,7 +388,7 @@ describe(signalSlice.name, () => {
 						load: (_state, $: Observable<void>) =>
 							$.pipe(
 								switchMap(() => block$),
-								map(() => ({}))
+								map(() => ({})),
 							),
 					},
 					actionEffects: () => ({
@@ -418,7 +418,7 @@ describe(signalSlice.name, () => {
 							$.pipe(
 								map(() => ({
 									age,
-								}))
+								})),
 							),
 					},
 					actionEffects: () => ({
@@ -457,7 +457,7 @@ describe(signalSlice.name, () => {
 							$.pipe(
 								map(() => {
 									throw error;
-								})
+								}),
 							),
 					},
 					actionEffects: () => ({

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -15,7 +15,7 @@ import { Subject, isObservable, share, take, type Observable } from 'rxjs';
 
 type ActionSourceFn<TSignalValue, TPayload> = (
 	state: Signal<TSignalValue>,
-	value: TPayload
+	value: TPayload,
 ) => Observable<PartialOrValue<TSignalValue>>;
 
 type NoOptionalProperties<T> = {
@@ -54,7 +54,7 @@ type ActionSourcePayloadType<TActionSource> = InferPayload<TActionSource>;
 
 type ActionSourceReturnType<TActionSource> = TActionSource extends (
 	state: any,
-	value: any
+	value: any,
 ) => Observable<infer TValue>
 	? TValue
 	: never;
@@ -73,44 +73,44 @@ type ActionEffects<TActionSources> = NamedActionEffects<TActionSources>;
 type Action<TSignalValue, TValue> = TValue extends [void]
 	? () => Promise<TSignalValue>
 	: [unknown] extends TValue
-	? () => Promise<TSignalValue>
-	: (
-			value: TValue extends [infer TInferred]
-				? TInferred | Observable<TInferred>
-				: TValue | Observable<TValue>
-	  ) => Promise<TSignalValue>;
+	  ? () => Promise<TSignalValue>
+	  : (
+				value: TValue extends [infer TInferred]
+					? TInferred | Observable<TInferred>
+					: TValue | Observable<TValue>,
+	    ) => Promise<TSignalValue>;
 
 type ActionMethod<
 	TSignalValue,
-	TActionSource extends NamedActionSources<TSignalValue>[string]
+	TActionSource extends NamedActionSources<TSignalValue>[string],
 > = TActionSource extends (
 	state: Signal<TSignalValue>,
-	value: Observable<infer TObservableValue>
+	value: Observable<infer TObservableValue>,
 ) => any
 	? Action<TSignalValue, [TObservableValue]>
 	: TActionSource extends Subject<infer TSubjectValue>
-	? Action<TSignalValue, [TSubjectValue]>
-	: never;
+	  ? Action<TSignalValue, [TSubjectValue]>
+	  : never;
 
 type ActionMethods<
 	TSignalValue,
-	TActionSources extends NamedActionSources<TSignalValue>
+	TActionSources extends NamedActionSources<TSignalValue>,
 > = {
 	[K in keyof TActionSources]: ActionMethod<TSignalValue, TActionSources[K]>;
 };
 
 type ActionStreams<
 	TSignalValue,
-	TActionSources extends NamedActionSources<TSignalValue>
+	TActionSources extends NamedActionSources<TSignalValue>,
 > = {
 	[K in keyof TActionSources &
 		string as `${K}$`]: TActionSources[K] extends Reducer<TSignalValue, unknown>
 		? Observable<void>
 		: TActionSources[K] extends Reducer<TSignalValue, infer TValue>
-		? TValue extends Observable<any>
-			? TValue
-			: Observable<TValue>
-		: never;
+		  ? TValue extends Observable<any>
+				? TValue
+				: Observable<TValue>
+		  : never;
 };
 
 export type Source<TSignalValue> = Observable<PartialOrValue<TSignalValue>>;
@@ -123,7 +123,7 @@ export type SignalSlice<
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects,
-	TActionEffects extends NamedActionEffects<TActionSources>
+	TActionEffects extends NamedActionEffects<TActionSources>,
 > = Signal<TSignalValue> &
 	Selectors<TSignalValue> &
 	ExtraSelectors<TSelectors> &
@@ -137,7 +137,7 @@ export function signalSlice<
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects,
-	TActionEffects extends NamedActionEffects<TActionSources>
+	TActionEffects extends NamedActionEffects<TActionSources>,
 >(config: {
 	initialState: TSignalValue;
 	sources?: SourceConfig<TSignalValue>;
@@ -150,7 +150,7 @@ export function signalSlice<
 			any,
 			TEffects,
 			TActionEffects
-		>
+		>,
 	) => TSelectors;
 	effects?: (
 		state: SignalSlice<
@@ -159,7 +159,7 @@ export function signalSlice<
 			TSelectors,
 			any,
 			TActionEffects
-		>
+		>,
 	) => TEffects;
 	actionEffects?: (
 		state: SignalSlice<
@@ -168,7 +168,7 @@ export function signalSlice<
 			TSelectors,
 			any,
 			TActionEffects
-		>
+		>,
 	) => TActionEffects;
 }): SignalSlice<
 	TSignalValue,
@@ -217,7 +217,7 @@ export function signalSlice<
 	connectSources(state, sources);
 
 	for (const [key, actionSource] of Object.entries(
-		actionSources as TActionSources
+		actionSources as TActionSources,
 	)) {
 		const effectTrigger = new Subject<any>();
 		subs.push(effectTrigger);
@@ -230,7 +230,7 @@ export function signalSlice<
 				destroyRef,
 				actionSource,
 				subs,
-				effectTrigger
+				effectTrigger,
 			);
 		} else {
 			const subject = new Subject();
@@ -245,7 +245,7 @@ export function signalSlice<
 				subject,
 				subs,
 				effectTrigger,
-				sharedObservable
+				sharedObservable,
 			);
 		}
 
@@ -309,7 +309,7 @@ function connectSources<TSignalValue>(
 	state: WritableSignal<TSignalValue>,
 	sources: SourceConfig<TSignalValue>,
 	injector?: Injector,
-	useUntracked = false
+	useUntracked = false,
 ) {
 	for (const source of sources) {
 		if (isObservable(source)) {
@@ -328,7 +328,7 @@ function addReducerProperties(
 	subject: Subject<unknown>,
 	subs: Subject<unknown>[],
 	effectTrigger: Subject<any>,
-	observableFromActionSource?: Observable<any>
+	observableFromActionSource?: Observable<any>,
 ) {
 	Object.defineProperties(readonlyState, {
 		[key]: {

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -15,7 +15,7 @@ import { Subject, isObservable, share, take, type Observable } from 'rxjs';
 
 type ActionSourceFn<TSignalValue, TPayload> = (
 	state: Signal<TSignalValue>,
-	value: TPayload,
+	value: TPayload
 ) => Observable<PartialOrValue<TSignalValue>>;
 
 type NoOptionalProperties<T> = {
@@ -54,7 +54,7 @@ type ActionSourcePayloadType<TActionSource> = InferPayload<TActionSource>;
 
 type ActionSourceReturnType<TActionSource> = TActionSource extends (
 	state: any,
-	value: any,
+	value: any
 ) => Observable<infer TValue>
 	? TValue
 	: never;
@@ -73,44 +73,44 @@ type ActionEffects<TActionSources> = NamedActionEffects<TActionSources>;
 type Action<TSignalValue, TValue> = TValue extends [void]
 	? () => Promise<TSignalValue>
 	: [unknown] extends TValue
-	  ? () => Promise<TSignalValue>
-	  : (
-				value: TValue extends [infer TInferred]
-					? TInferred | Observable<TInferred>
-					: TValue | Observable<TValue>,
-	    ) => Promise<TSignalValue>;
+	? () => Promise<TSignalValue>
+	: (
+			value: TValue extends [infer TInferred]
+				? TInferred | Observable<TInferred>
+				: TValue | Observable<TValue>
+	  ) => Promise<TSignalValue>;
 
 type ActionMethod<
 	TSignalValue,
-	TActionSource extends NamedActionSources<TSignalValue>[string],
+	TActionSource extends NamedActionSources<TSignalValue>[string]
 > = TActionSource extends (
 	state: Signal<TSignalValue>,
-	value: Observable<infer TObservableValue>,
+	value: Observable<infer TObservableValue>
 ) => any
 	? Action<TSignalValue, [TObservableValue]>
 	: TActionSource extends Subject<infer TSubjectValue>
-	  ? Action<TSignalValue, [TSubjectValue]>
-	  : never;
+	? Action<TSignalValue, [TSubjectValue]>
+	: never;
 
 type ActionMethods<
 	TSignalValue,
-	TActionSources extends NamedActionSources<TSignalValue>,
+	TActionSources extends NamedActionSources<TSignalValue>
 > = {
 	[K in keyof TActionSources]: ActionMethod<TSignalValue, TActionSources[K]>;
 };
 
 type ActionStreams<
 	TSignalValue,
-	TActionSources extends NamedActionSources<TSignalValue>,
+	TActionSources extends NamedActionSources<TSignalValue>
 > = {
 	[K in keyof TActionSources &
 		string as `${K}$`]: TActionSources[K] extends Reducer<TSignalValue, unknown>
 		? Observable<void>
 		: TActionSources[K] extends Reducer<TSignalValue, infer TValue>
-		  ? TValue extends Observable<any>
-				? TValue
-				: Observable<TValue>
-		  : never;
+		? TValue extends Observable<any>
+			? TValue
+			: Observable<TValue>
+		: never;
 };
 
 export type Source<TSignalValue> = Observable<PartialOrValue<TSignalValue>>;
@@ -123,7 +123,7 @@ export type SignalSlice<
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects,
-	TActionEffects extends NamedActionEffects<TActionSources>,
+	TActionEffects extends NamedActionEffects<TActionSources>
 > = Signal<TSignalValue> &
 	Selectors<TSignalValue> &
 	ExtraSelectors<TSelectors> &
@@ -137,7 +137,7 @@ export function signalSlice<
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects,
-	TActionEffects extends NamedActionEffects<TActionSources>,
+	TActionEffects extends NamedActionEffects<TActionSources>
 >(config: {
 	initialState: TSignalValue;
 	sources?: SourceConfig<TSignalValue>;
@@ -150,7 +150,7 @@ export function signalSlice<
 			any,
 			TEffects,
 			TActionEffects
-		>,
+		>
 	) => TSelectors;
 	effects?: (
 		state: SignalSlice<
@@ -159,7 +159,7 @@ export function signalSlice<
 			TSelectors,
 			any,
 			TActionEffects
-		>,
+		>
 	) => TEffects;
 	actionEffects?: (
 		state: SignalSlice<
@@ -168,7 +168,7 @@ export function signalSlice<
 			TSelectors,
 			any,
 			TActionEffects
-		>,
+		>
 	) => TActionEffects;
 }): SignalSlice<
 	TSignalValue,
@@ -217,7 +217,7 @@ export function signalSlice<
 	connectSources(state, sources);
 
 	for (const [key, actionSource] of Object.entries(
-		actionSources as TActionSources,
+		actionSources as TActionSources
 	)) {
 		const effectTrigger = new Subject<any>();
 		subs.push(effectTrigger);
@@ -230,7 +230,7 @@ export function signalSlice<
 				destroyRef,
 				actionSource,
 				subs,
-				effectTrigger,
+				effectTrigger
 			);
 		} else {
 			const subject = new Subject();
@@ -245,7 +245,7 @@ export function signalSlice<
 				subject,
 				subs,
 				effectTrigger,
-				sharedObservable,
+				sharedObservable
 			);
 		}
 
@@ -286,14 +286,21 @@ export function signalSlice<
 		subs.forEach((sub) => sub.complete());
 	});
 
+	const connectLazySources = () => {
+		if (!lazySourcesLoaded) {
+			lazySourcesLoaded = true;
+			connectSources(state, lazySources, injector, true);
+		}
+	};
+
 	return new Proxy(slice, {
 		get(target, property, receiver) {
-			if (!lazySourcesLoaded) {
-				lazySourcesLoaded = true;
-				connectSources(state, lazySources, injector, true);
-			}
-
+			connectLazySources();
 			return Reflect.get(target, property, receiver);
+		},
+		apply(target, thisArg, argumentsList) {
+			connectLazySources();
+			return Reflect.apply(target, thisArg, argumentsList);
 		},
 	});
 }
@@ -302,7 +309,7 @@ function connectSources<TSignalValue>(
 	state: WritableSignal<TSignalValue>,
 	sources: SourceConfig<TSignalValue>,
 	injector?: Injector,
-	useUntracked = false,
+	useUntracked = false
 ) {
 	for (const source of sources) {
 		if (isObservable(source)) {
@@ -321,7 +328,7 @@ function addReducerProperties(
 	subject: Subject<unknown>,
 	subs: Subject<unknown>[],
 	effectTrigger: Subject<any>,
-	observableFromActionSource?: Observable<any>,
+	observableFromActionSource?: Observable<any>
 ) {
 	Object.defineProperties(readonlyState, {
 		[key]: {


### PR DESCRIPTION
Fixes the issues discussed here: https://github.com/nartc/ngxtension-platform/issues/196 where lazySources were not being connected if the state signal value was accessed directly.

P.S. not sure what is happening with the formatting/trailing commas, let me know if I need to fix something here
