### PR TITLE
docs: third arg is the options-obj for computedFrom

### DIFF
--- a/docs/src/content/docs/utilities/Signals/computed-from.md
+++ b/docs/src/content/docs/utilities/Signals/computed-from.md
@@ -99,8 +99,8 @@ let c = computedFrom(
 		switchMap(
 			([a, b]) => of(a + b).pipe(delay(1000)), // later async emit value
 		),
-		{ initialValue: 42 }, // 👈 pass the initial value of the resulting signal
 	),
+	{ initialValue: 42 }, // 👈 pass the initial value of the resulting signal
 );
 ```
 


### PR DESCRIPTION
The `options`-object is currently inside the `pipe`. This moves it to be the 3rd argument of the `computedFrom`-function.