### PR TITLE
refactor(NgxControlError): improve statematcher

### DIFF
--- a/docs/src/content/docs/es/utilities/Forms/control-error.md
+++ b/docs/src/content/docs/es/utilities/Forms/control-error.md
@@ -6,7 +6,7 @@ entryPoint: control-error
 contributor: robby-rabbitman
 ---
 
-`NgxControlError` es una directiva estructural para mostrar errores de control de formulario de manera consistente y reducir el código repetitivo.
+`NgxControlError` es una directiva estructural para mostrar consistentemente los errores de los controles de formulario, reduciendo al mismo tiempo la redundancia de código.
 
 ## Importar
 
@@ -26,7 +26,7 @@ import { NgxControlError } from 'ngxtension/control-error';
 </label>
 ```
 
-La plantilla se renderizará cuando el control esté en un [_estado de error_](#configuración) y sus errores incluyan el/los error(es) rastreado(s).
+La plantilla se renderizará cuando el control esté en un [_estado de error_](#configuration) y sus errores incluyan el/los error(es) rastreado(s).
 
 Sin `NgxControlError`:
 
@@ -43,8 +43,8 @@ Sin `NgxControlError`:
 ## Configuración
 
 Un `StateMatcher` define cuándo el control proporcionado está en un _estado de error_.
-Un `StateMatcher` es una función que devuelve un observable.
-La directiva **SOLO** renderiza la plantilla cuando el `StateMatcher` emite `true`.
+Un `StateMatcher` es una función que devuelve un observable. Cada vez que el `StateMatcher` emite un valor, la directiva verifica si debe renderizar u ocultar su plantilla:
+La directiva renderiza su plantilla cuando el `StateMatcher` emite `true` y los errores del control incluyen al menos un error rastreado, de lo contrario, su plantilla estará oculta.
 
 ```ts
 export type StateMatcher = (
@@ -53,9 +53,22 @@ export type StateMatcher = (
 ) => Observable<boolean>;
 ```
 
-Por defecto, el control se considera en un _estado de error_ cuando 1. su estado es `INVALID` y 2. está tocado o su formulario se ha enviado.
+Por defecto, se considera que el control está en un _estado de error_ cuando 1. su estado es `INVALID` y 2. está `touched` o su formulario ha sido `submitted`.
 
-Puede anular este comportamiento:
+Puedes anular este comportamiento:
+
+```ts
+/**
+ * Un control está en un estado de error cuando su estado es inválido.
+ * Emite siempre que statusChanges emita.
+ * Puedes querer agregar más fuentes, como valueChanges.
+ */
+export const customErrorStateMatcher: StateMatcher = (control) =>
+	control.statusChanges.pipe(
+		startWith(control.status),
+		map((status) => status === 'INVALID'),
+	);
+```
 
 ### DI
 
@@ -81,7 +94,7 @@ provideNgxControlError({ errorStateMatcher: customErrorStateMatcher });
 
 ### [NGX Translate](https://github.com/ngx-translate/core)
 
-Puede iterar sobre todos los posibles errores y pasar los `errors` al tubo de traducción:
+Puedes iterar sobre todos los errores posibles y pasar los `errors` al pipe de traducción:
 
 ```html
 <label>
@@ -89,8 +102,7 @@ Puede iterar sobre todos los posibles errores y pasar los `errors` al tubo de tr
 	<input type="email" [formControl]="mail" />
 	@for (error of ['required', 'email', 'myCustomError']; track error) {
 	<strong *ngxControlError="mail; track: error">
-		{{ "RUTA.A.ERRORES.DE.CONTROL.DE.CORREO." + error | translate: mail.errors
-		}}
+		{{ "RUTA.A.ERRORES.CONTROL.CORREO." + error | translate: mail.errors }}
 	</strong>
 	}
 </label>

--- a/docs/src/content/docs/utilities/Forms/control-error.md
+++ b/docs/src/content/docs/utilities/Forms/control-error.md
@@ -41,8 +41,8 @@ without `NgxControlError`:
 ## Configuration
 
 A `StateMatcher` defines when the provided control is in an _error state_.
-A `StateMatcher` is a function which returns an observable.
-The directive **ONLY** renders the template when the `StateMatcher` emits `true`.
+A `StateMatcher` is a function which returns an observable. Every time the `StateMatcher` emits a value, the directive checks whether it should render or hide its template:
+The directive renders its template when the `StateMatcher` emits `true` and the errors of the control include at least 1 tracked error, else its template will be hidden.
 
 ```ts
 export type StateMatcher = (
@@ -51,9 +51,22 @@ export type StateMatcher = (
 ) => Observable<boolean>;
 ```
 
-Per default the control is considered in an _error state_ when 1. its status is `INVALID` and 2. it is touched or its form has been submitted.
+Per default the control is considered in an _error state_ when 1. its status is `INVALID` and 2. it is `touched` or its form has been `submitted`.
 
 You can override this behavior:
+
+```ts
+/**
+ * A control is in an error state when its status is invalid.
+ * Emits whenever statusChanges emits.
+ * You may want to add more sources, such as valueChanges.
+ */
+export const customErrorStateMatcher: StateMatcher = (control) =>
+	control.statusChanges.pipe(
+		startWith(control.status),
+		map((status) => status === 'INVALID'),
+	);
+```
 
 ### Via DI
 


### PR DESCRIPTION
Improve configuration section in docs

reduce emits of NGX_DEFAULT_CONTROL_ERROR_STATE_MATCHER

share statematcher computation in  NgxControlError