### PR TITLE
feat(create-injection-token): add createService

### DIFF
--- a/libs/ngxtension/create-injection-token/src/create-injection-token.spec.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.spec.ts
@@ -183,12 +183,14 @@ describe(createNoopInjectionToken.name, () => {
 });
 
 describe(createService.name, () => {
-	it('should work', () => {
-		const [injectFn] = createService(() => 1);
+	it('should be able to access property returned from service', () => {
+		const [injectFn] = createService(() => {
+			return { someProp: 1 };
+		});
 
 		TestBed.runInInjectionContext(() => {
-			const value = injectFn();
-			expect(value).toEqual(1);
+			const service = injectFn();
+			expect(service.someProp).toEqual(1);
 		});
 	});
 });

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.spec.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import {
 	createInjectionToken,
 	createNoopInjectionToken,
+	createService,
 } from './create-injection-token';
 
 describe(createInjectionToken.name, () => {
@@ -177,6 +178,17 @@ describe(createNoopInjectionToken.name, () => {
 				const values = injectFn();
 				expect(values).toEqual([1, 2]);
 			});
+		});
+	});
+});
+
+describe(createService.name, () => {
+	it('should work', () => {
+		const [injectFn] = createService(() => 1);
+
+		TestBed.runInInjectionContext(() => {
+			const value = injectFn();
+			expect(value).toEqual(1);
 		});
 	});
 });

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.ts
@@ -48,6 +48,17 @@ export type CreateInjectionTokenOptions<
 		extraProviders?: Provider | EnvironmentProviders;
 	};
 
+export type CreateServiceOptions<
+	TFactory extends (...args: any[]) => any,
+	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
+> = (TFactoryDeps[0] extends undefined
+	? { deps?: never }
+	: { deps: CreateInjectionTokenDeps<TFactory, TFactoryDeps> }) & {
+	isRoot?: boolean;
+	token?: InjectionToken<ReturnType<TFactory>>;
+	extraProviders?: Provider | EnvironmentProviders;
+};
+
 type CreateProvideFnOptions<
 	TFactory extends (...args: any[]) => any,
 	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
@@ -261,4 +272,18 @@ export function createNoopInjectionToken<
 		token,
 		() => {},
 	] as CreateInjectionTokenReturn<TReturn, true>;
+}
+
+export function createService<
+	TFactory extends (...args: any[]) => any,
+	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
+	TOptions extends CreateInjectionTokenOptions<
+		TFactory,
+		TFactoryDeps
+	> = CreateServiceOptions<TFactory, TFactoryDeps>,
+>(
+	factory: TFactory,
+	options?: TOptions,
+): CreateInjectionTokenReturn<ReturnType<TFactory>> {
+	return createInjectionToken(factory, options);
 }

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.ts
@@ -49,7 +49,7 @@ export type CreateInjectionTokenOptions<
 	};
 
 export type CreateServiceOptions<
-	TFactory extends (...args: any[]) => any,
+	TFactory extends (...args: any[]) => object,
 	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
 > = (TFactoryDeps[0] extends undefined
 	? { deps?: never }
@@ -275,7 +275,7 @@ export function createNoopInjectionToken<
 }
 
 export function createService<
-	TFactory extends (...args: any[]) => any,
+	TFactory extends (...args: any[]) => object,
 	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
 	TOptions extends CreateInjectionTokenOptions<
 		TFactory,


### PR DESCRIPTION
This adds a `createService` abstraction for `createInjectionToken`. The primary purpose is to make the API more appealing for the role of creating a service using `createInjectionToken` and is mostly cosmetic. However, `createService` currently does not allow using the `multi` option as this does not make sense for services, and it will also require that the factory function returns an object.