### PR TITLE
fix(connect): handle null when performing typeof object

### DIFF
--- a/libs/ngxtension/connect/src/connect.spec.ts
+++ b/libs/ngxtension/connect/src/connect.spec.ts
@@ -334,4 +334,47 @@ describe(connect.name, () => {
 			expect(component.count()).toBe(1); // should not change
 		});
 	});
+
+	describe('connects an observable with single emit to a null signal in injection context', () => {
+		@Component({ standalone: true, template: '' })
+		class TestComponent {
+			text = signal<string | null>(null);
+
+			constructor() {
+				connect(this.text, of('text'));
+			}
+		}
+
+		let component: TestComponent;
+		let fixture: ComponentFixture<TestComponent>;
+
+		beforeEach(async () => {
+			fixture = TestBed.createComponent(TestComponent);
+			component = fixture.componentInstance;
+		});
+		it('works fine', () => {
+			expect(component.text()).toBe('text');
+		});
+	});
+	describe('connects an observable with multiple emits to a null signal in injection context', () => {
+		@Component({ standalone: true, template: '' })
+		class TestComponent {
+			text = signal<string | null>(null);
+
+			constructor() {
+				connect(this.text, of('text', null, 'text2'));
+			}
+		}
+
+		let component: TestComponent;
+		let fixture: ComponentFixture<TestComponent>;
+
+		beforeEach(async () => {
+			fixture = TestBed.createComponent(TestComponent);
+			component = fixture.componentInstance;
+		});
+		it('works fine', () => {
+			expect(component.text()).toBe('text2');
+		});
+	});
 });

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -116,7 +116,12 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 		return observable.pipe(takeUntilDestroyed(destroyRef)).subscribe((x) => {
 			const update = () => {
 				signal.update((prev) => {
-					if (typeof prev === 'object' && !Array.isArray(prev)) {
+					if (
+						prev !== undefined &&
+						prev !== null &&
+						typeof prev === 'object' &&
+						!Array.isArray(prev)
+					) {
 						return { ...prev, ...((reducer?.(prev, x) || x) as object) };
 					}
 


### PR DESCRIPTION
Ignore `null` and `undefined` values of signal before performing `typeof object` comparison for spread operator

Fixes #157 