### PR TITLE
docs(NgxSvgSprite): align provideSvgSprites sections with implementation

### DIFF
--- a/docs/src/content/docs/es/utilities/Assets/svg-sprites.md
+++ b/docs/src/content/docs/es/utilities/Assets/svg-sprites.md
@@ -60,12 +60,10 @@ export class FaBrandSvg {
 Para renderizar un símbolo, es necesario proporcionar sprites.
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'fa-brands',
-		baseUrl: 'assets/fontawesome/sprites/brands.svg',
-	}),
-);
+provideSvgSprites({
+	name: 'fa-brands',
+	baseUrl: 'assets/fontawesome/sprites/brands.svg',
+});
 ```
 
 La propiedad `name` puede hacer referencia a cualquier valor arbitrario, pero debe ser única, ya que puedes registrar múltiples sprites de svg diferentes.
@@ -85,13 +83,11 @@ Este comportamiento se puede deshabilitar.
 La Auto View Box está deshabilitada para el sprite de svg.
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'fa-brands',
-		baseUrl: 'assets/fontawesome/sprites/brands.svg',
-		autoViewBox: false,
-	}),
-);
+provideSvgSprites({
+	name: 'fa-brands',
+	baseUrl: 'assets/fontawesome/sprites/brands.svg',
+	autoViewBox: false,
+});
 ```
 
 #### Deshabilitar mediante la Entrada `autoViewBoxDisabled`
@@ -115,25 +111,21 @@ La Auto View Box está deshabilitada para un elemento `svg` cuando el atributo `
 Cuando se establece la función `classes`, se agregarán una lista de clases al `NgxSvgSpriteFragment` en su host.
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'my-sprite',
-		baseUrl: 'path/to/my/sprite.svg',
-		classes: (fragment) => ['some-class', `some-other-class-${fragment}`],
-	}),
-);
+provideSvgSprites({
+	name: 'my-sprite',
+	baseUrl: 'path/to/my/sprite.svg',
+	classes: (fragment) => ['some-class', `some-other-class-${fragment}`],
+});
 ```
 
 ### Url
 
-Por defecto, al usar la función `createSvgSprite`, la `url` devolverá `'${baseUrl}#${fragment}'`. Esto se puede sobrescribir:
+Por defecto, al proporcionar un sprite, la propiedad `url` devolverá `'${baseUrl}#${fragment}'`. Esto puede ser sobrescrito:
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'my-sprite',
-		baseUrl: 'path/to/my/sprite.svg',
-		url: (baseUrl, fragment) => `${baseUrl}#some-prefix-${fragment}`,
-	}),
-);
+provideSvgSprites({
+	name: 'my-sprite',
+	baseUrl: 'path/to/my/sprite.svg',
+	url: (baseUrl, fragment) => `${baseUrl}#some-prefix-${fragment}`,
+});
 ```

--- a/docs/src/content/docs/utilities/Assets/svg-sprites.md
+++ b/docs/src/content/docs/utilities/Assets/svg-sprites.md
@@ -60,12 +60,10 @@ export class FaBrandSvg {
 In order to render a symbol, sprites have to be provided.
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'fa-brands',
-		baseUrl: 'assets/fontawesome/sprites/brands.svg',
-	}),
-);
+provideSvgSprites({
+	name: 'fa-brands',
+	baseUrl: 'assets/fontawesome/sprites/brands.svg',
+});
 ```
 
 The `name` property can reference any arbitrary value, but should be unique, since you can register multiple different svg sprites.
@@ -85,13 +83,11 @@ This behavior can be disabled.
 Auto View Box is disabled for the svg sprite.
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'fa-brands',
-		baseUrl: 'assets/fontawesome/sprites/brands.svg',
-		autoViewBox: false,
-	}),
-);
+provideSvgSprites({
+	name: 'fa-brands',
+	baseUrl: 'assets/fontawesome/sprites/brands.svg',
+	autoViewBox: false,
+});
 ```
 
 #### Disable via `autoViewBoxDisabled` Input
@@ -115,25 +111,21 @@ Auto View Box is disabled for a `svg` element, when the `viewBox` attribute alre
 When the `classes` function is set, a list of classes will be added by the `NgxSvgSpriteFragment` to its host.
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'my-sprite',
-		baseUrl: 'path/to/my/sprite.svg',
-		classes: (fragment) => ['some-class', `some-other-class-${fragment}`],
-	}),
-);
+provideSvgSprites({
+	name: 'my-sprite',
+	baseUrl: 'path/to/my/sprite.svg',
+	classes: (fragment) => ['some-class', `some-other-class-${fragment}`],
+});
 ```
 
 ### Url
 
-Per default when using the `createSvgSprite` function, the `url` will return `'${baseUrl}#${fragment}'`. This can be overwritten:
+Per default when providing a sprite, the `url` will return `'${baseUrl}#${fragment}'`. This can be overwritten:
 
 ```ts
-provideSvgSprites(
-	createSvgSprite({
-		name: 'my-sprite',
-		baseUrl: 'path/to/my/sprite.svg',
-		url: (baseUrl, fragment) => `${baseUrl}#some-prefix-${fragment}`,
-	}),
-);
+provideSvgSprites({
+	name: 'my-sprite',
+	baseUrl: 'path/to/my/sprite.svg',
+	url: (baseUrl, fragment) => `${baseUrl}#some-prefix-${fragment}`,
+});
 ```

--- a/libs/ngxtension/svg-sprite/src/svg-sprite.ts
+++ b/libs/ngxtension/svg-sprite/src/svg-sprite.ts
@@ -182,7 +182,7 @@ const createSvgSprite = (options: CreateNgxSvgSpriteOptions) => {
  *
  * ```html
  * <svg viewBox="0 0 496 512">
- * <use href="assets/fontawesome/sprites/brands.svg#github"></use>
+ * 	<use href="assets/fontawesome/sprites/brands.svg#github"></use>
  * </svg>
  * ```
  *
@@ -198,16 +198,16 @@ const createSvgSprite = (options: CreateNgxSvgSpriteOptions) => {
  *
  * ```ts
  * @Directive({
- * selector: 'svg[faBrand]',
- * standalone: true,
- * hostDirectives: [
- * { directive: NgxSvgSpriteFragment, inputs: ['fragment:faBrand'] },
- * ],
+ * 	selector: 'svg[faBrand]',
+ * 	standalone: true,
+ * 	hostDirectives: [
+ * 		{ directive: NgxSvgSpriteFragment, inputs: ['fragment:faBrand'] },
+ * 	],
  * })
  * export class FaBrandSvg {
- * constructor() {
- * inject(NgxSvgSpriteFragment).sprite = 'fa-brands';
- * }
+ * 	constructor() {
+ * 		inject(NgxSvgSpriteFragment).sprite = 'fa-brands';
+ * 	}
  * }
  * ```
  *
@@ -216,12 +216,10 @@ const createSvgSprite = (options: CreateNgxSvgSpriteOptions) => {
  * In order to render a symbol, sprites have to be provided.
  *
  * ```ts
- * provideSvgSprites(
- * createSvgSprite({
- * name: 'fa-brands',
- * baseUrl: 'assets/fontawesome/sprites/brands.svg',
- * }),
- * );
+ * provideSvgSprites({
+ * 	name: 'fa-brands',
+ * 	baseUrl: 'assets/fontawesome/sprites/brands.svg',
+ * });
  * ```
  *
  * The `name` property can reference any arbitrary value, but should be unique, since you can register multiple different svg sprites.
@@ -241,13 +239,11 @@ const createSvgSprite = (options: CreateNgxSvgSpriteOptions) => {
  * Auto View Box is disabled for the svg sprite.
  *
  * ```ts
- * provideSvgSprites(
- * createSvgSprite({
- * name: 'fa-brands',
- * baseUrl: 'assets/fontawesome/sprites/brands.svg',
- * autoViewBox: false,
- * }),
- * );
+ * provideSvgSprites({
+ * 	name: 'fa-brands',
+ * 	baseUrl: 'assets/fontawesome/sprites/brands.svg',
+ * 	autoViewBox: false,
+ * });
  * ```
  *
  * #### Disable via `autoViewBoxDisabled` Input
@@ -271,27 +267,23 @@ const createSvgSprite = (options: CreateNgxSvgSpriteOptions) => {
  * When the `classes` function is set, a list of classes will be added by the `NgxSvgSpriteFragment` to its host.
  *
  * ```ts
- * provideSvgSprites(
- * createSvgSprite({
- * name: 'my-sprite',
- * baseUrl: 'path/to/my/sprite.svg',
- * classes: (fragment) => ['some-class', `some-other-class-${fragment}`],
- * }),
- * );
+ * provideSvgSprites({
+ * 	name: 'my-sprite',
+ * 	baseUrl: 'path/to/my/sprite.svg',
+ * 	classes: (fragment) => ['some-class', `some-other-class-${fragment}`],
+ * });
  * ```
  *
  * ### Url
  *
- * Per default when using the `createSvgSprite` function, the `url` will return `'${baseUrl}#${fragment}'`. This can be overwritten:
+ * Per default when providing a sprite, the `url` will return `'${baseUrl}#${fragment}'`. This can be overwritten:
  *
  * ```ts
- * provideSvgSprites(
- * createSvgSprite({
- * name: 'my-sprite',
- * baseUrl: 'path/to/my/sprite.svg',
- * url: (baseUrl, fragment) => `${baseUrl}#some-prefix-${fragment}`,
- * }),
- * );
+ * provideSvgSprites({
+ * 	name: 'my-sprite',
+ * 	baseUrl: 'path/to/my/sprite.svg',
+ * 	url: (baseUrl, fragment) => `${baseUrl}#some-prefix-${fragment}`,
+ * });
  * ```
  */
 @Directive({


### PR DESCRIPTION
`createSvgSprite` is an internal method, which gets called by provideSvgSprites. So remove it from the docs.

@nartc Please have a look at this quick fix of the docs!

Cheers 😃 