### PR TITLE
feat: added computed-async impl

### DIFF
--- a/docs/src/content/docs/utilities/Signals/computed-async.md
+++ b/docs/src/content/docs/utilities/Signals/computed-async.md
@@ -140,3 +140,26 @@ If we want to keep the previous computation, but also wait for it to complete be
 If we want to ignore the new computation if the previous one is not completed, we can use the `exhaust` behavior.
 
 - Uses `exhaustMap` operator
+
+### Use with previous computed value
+
+If we want to use the previous computed value in the next computation, we can read it in the callback function as the first argument.
+
+```ts movie-card.ts
+import { injectQueryParams } from 'ngxtension/inject-query-params';
+
+export class UserTasks {
+	private http = inject(HttpClient);
+	userId = injectQueryParams('userId');
+
+	userTasks = computedAsync(
+		(previousTasks) => {
+			// Use previousTasks to do something
+			return this.http.get(
+				`https://localhost/api/tasks?userId=${this.userId()}`,
+			);
+		},
+		{ initialValue: [] },
+	);
+}
+```

--- a/docs/src/content/docs/utilities/Signals/computed-async.md
+++ b/docs/src/content/docs/utilities/Signals/computed-async.md
@@ -1,0 +1,142 @@
+---
+title: computedAsync
+description: ngxtension/computed-async
+entryPoint: computed-async
+badge: stable
+contributor: enea-jahollari
+---
+
+`computedAsync` is a helper function that allows us to compute a value based on a Promise or Observable, but also supports return regular values (that are not Promises or Observables).
+It also gives us the possibility to change the behavior of the computation by choosing the flattening strategy (switch, merge, concat, exhaust) and the initial value of the computed value.
+
+```ts
+import { computedAsync } from 'ngxtension/computed-async';
+```
+
+## Usage
+
+`computedAsync` accepts a function that returns a `Promise`, `Observable`, or a regular value, and returns a `Signal` that emits the computed value.
+
+#### Example with Promise (fetch)
+
+```ts movie-card.ts
+export class MovieCard {
+	movieId = input.required<string>();
+
+	movie = computedAsync(() =>
+		fetch(`https://localhost/api/movies/${this.movieId()}`).then((r) =>
+			r.json(),
+		),
+	);
+}
+```
+
+#### Example with Observable (HttpClient)
+
+When we return an `Observable`, it will be automatically subscribed to, and will be unsubscribed when the component is destroyed.
+
+In the example below, if the `movieId` changes, the previous computation will be cancelled (if it's an API call, it's going to be cancelled too), and a new one will be triggered.
+
+```ts movie-card.ts
+import { inject } from '@angular/core';
+
+export class MovieCard {
+	private http = inject(HttpClient);
+
+	movieId = input.required<string>();
+
+	movie = computedAsync(() =>
+		this.http.get(`https://localhost/api/movies/${this.movieId()}`),
+	);
+}
+```
+
+#### Example with regular value
+
+```ts movie-card.ts
+export class MovieCard {
+	movieId = input.required<string>();
+
+	movie = computedAsync(() => (this.movieId() ? '🍿' : '🎬'));
+}
+```
+
+#### Example with initialValue
+
+```ts
+import { injectQueryParams } from 'ngxtension/inject-query-params';
+
+export class UserTasks {
+	userId = injectQueryParams('userId');
+
+	userTasks = computedAsync(
+		() => fetch(`https://localhost/api/tasks?userId=${this.userId()}`),
+		{ initialValue: [] },
+	);
+}
+```
+
+#### Usage outside of injection context
+
+By default, it needs to be called in an injection context, but it can also be called outside of it by passing the `Injector` in the second argument `options` object.
+
+```ts
+import { inject, Injector } from '@angular/core';
+import { computedAsync } from 'ngxtension/computed-async';
+
+export class UserTasks {
+	private injector = inject(Injector);
+	private userId = injectQueryParams('userId');
+
+	userTasks!: Signal<Task[]>;
+
+	ngOnInit() {
+		this.userTasks = computedAsync(
+			() => fetch(`https://localhost/api/tasks?userId=${this.userId()}`),
+			{ injector: this.injector },
+		);
+	}
+}
+```
+
+### Behaviors (switch, merge, concat, exhaust)
+
+By default, `computedAsync` uses the `switch` behavior, which means that if the computation is triggered again before the previous one is completed, the previous one will be cancelled.
+If you want to change the behavior, you can pass the `behavior` option in the second argument `options` object.
+
+```ts movie-card.ts
+export class MovieCard {
+	movieId = input.required<string>();
+
+	movie = computedAsync(
+		() => this.http.get(`https://localhost/api/movies/${this.movieId()}`),
+		{ behavior: 'concat' /* or 'merge', 'concat', 'exhaust' */ },
+	);
+}
+```
+
+#### switch (default)
+
+If we want to cancel the previous computation, we can use the `switch` behavior, which is the default behavior.
+If the computation is triggered again before the previous one is completed, the previous one will be cancelled.
+
+- Uses `switchMap` operator
+
+#### merge
+
+If we want to keep the previous computation, we can use the `merge` behavior.
+If the computation is triggered again before the previous one is completed, the previous one will be kept, and the new one will be started.
+
+- Uses `mergeMap` operator
+
+#### concat
+
+If we want to keep the previous computation, but also wait for it to complete before starting the new one, we can use the `concat` behavior.
+
+- Uses `concatMap` operator
+
+#### exhaust
+
+If we want to ignore the new computation if the previous one is not completed, we can use the `exhaust` behavior.
+
+- Uses `exhaustMap` operator

--- a/libs/ngxtension/computed-async/README.md
+++ b/libs/ngxtension/computed-async/README.md
@@ -1,0 +1,3 @@
+# ngxtension/computed-async
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/computed-async`.

--- a/libs/ngxtension/computed-async/ng-package.json
+++ b/libs/ngxtension/computed-async/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/computed-async/project.json
+++ b/libs/ngxtension/computed-async/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/computed-async",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/computed-async/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["computed-async"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/computed-async/src/computed-async.spec.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.spec.ts
@@ -158,34 +158,36 @@ describe(computedAsync.name, () => {
 
 	describe('is typesafe', () => {
 		it('initial value', () => {
-			const a: Signal<number> = computedAsync(() => {
-				if (Math.random() > 0.5) return Promise.resolve(1);
-				return Promise.resolve(1);
+			TestBed.runInInjectionContext(() => {
+				const a: Signal<number> = computedAsync(() => {
+					if (Math.random() > 0.5) return Promise.resolve(1);
+					return Promise.resolve(1);
+				});
+
+				const b: Signal<number> = computedAsync(() => {
+					if (Math.random() > 0.5) return of(1);
+					return of(1);
+				});
+
+				const c: Signal<number | null> = computedAsync(
+					() => {
+						return 1;
+					},
+					{ initialValue: null },
+				);
+
+				const d: Signal<string> = computedAsync(
+					() => {
+						return '';
+					},
+					{ initialValue: '' },
+				);
+
+				expect(a).toBeTruthy();
+				expect(b).toBeTruthy();
+				expect(c).toBeTruthy();
+				expect(d).toBeTruthy();
 			});
-
-			const b: Signal<number> = computedAsync(() => {
-				if (Math.random() > 0.5) return of(1);
-				return of(1);
-			});
-
-			const c: Signal<number | null> = computedAsync(
-				() => {
-					return 1;
-				},
-				{ initialValue: null },
-			);
-
-			const d: Signal<string> = computedAsync(
-				() => {
-					return '';
-				},
-				{ initialValue: '' },
-			);
-
-			expect(a).toBeTruthy();
-			expect(b).toBeTruthy();
-			expect(c).toBeTruthy();
-			expect(d).toBeTruthy();
 		});
 	});
 });

--- a/libs/ngxtension/computed-async/src/computed-async.spec.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.spec.ts
@@ -70,7 +70,10 @@ describe(computedAsync.name, () => {
 					if (previousValue !== undefined) {
 						logs.push(previousValue * 1000);
 					}
-					return promise(v, 100).then((x) => logs.push(x));
+					return promise(v, 100).then((x) => {
+						logs.push(x);
+						return x;
+					});
 				});
 
 				expect(s()).toEqual(undefined); // initial value

--- a/libs/ngxtension/computed-async/src/computed-async.spec.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.spec.ts
@@ -1,0 +1,158 @@
+import { signal } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { delay, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { computedAsync } from './computed-async';
+
+const promise = <T>(value: T, time: number = 0): Promise<T> =>
+	new Promise((resolve) => setTimeout(() => resolve(value), time));
+
+describe(computedAsync.name, () => {
+	describe('works with raw values', () => {
+		it('null & undefined', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const value = signal<null | undefined>(null);
+				const result = computedAsync(() => value());
+				expect(result()).toEqual(null); // initial value
+				value.set(undefined);
+				TestBed.flushEffects();
+				expect(result()).toEqual(undefined);
+			});
+		}));
+		it('objects', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const value = signal(0);
+				const data = signal([1, 2, 3]);
+
+				const result = computedAsync(() => {
+					return data().map((v) => v + value());
+				});
+
+				expect(result()).toEqual(null); // initial value
+				TestBed.flushEffects();
+				expect(result()).toEqual([1, 2, 3]);
+				value.set(1);
+				TestBed.flushEffects();
+				expect(result()).toEqual([2, 3, 4]);
+			});
+		}));
+		it('initialValue', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const value = signal(0);
+				const data = signal([1, 2, 3]);
+
+				const result = computedAsync(
+					() => {
+						return data().map((v) => v + value());
+					},
+					{ initialValue: [] },
+				);
+
+				expect(result()).toEqual([]); // initial value
+				TestBed.flushEffects();
+				expect(result()).toEqual([1, 2, 3]);
+				value.set(1);
+				TestBed.flushEffects();
+				expect(result()).toEqual([2, 3, 4]);
+			});
+		}));
+	});
+
+	describe('works with promises', () => {
+		it('waits for them to resolve', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const logs: number[] = [];
+				const value = signal(1);
+
+				const s = computedAsync(() => {
+					return promise(value(), 100).then((v) => logs.push(v));
+				});
+				expect(s()).toEqual(null); // initial value
+				TestBed.flushEffects();
+				expect(s()).toEqual(null); // initial value
+				tick(100); // wait 100ms for promise to resolve
+				expect(s()).toEqual(1);
+				expect(logs).toEqual([1]);
+
+				value.set(2);
+				TestBed.flushEffects();
+				expect(s()).toEqual(1); // still the old value
+				tick(100); // wait 100ms for promise to resolve
+				expect(s()).toEqual(2);
+				expect(logs).toEqual([1, 2]);
+			});
+		}));
+	});
+
+	describe('works with observables', () => {
+		it('waits for them to resolve', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const logs: number[] = [];
+				const value = signal(1);
+
+				const s = computedAsync(() => {
+					return of(value()).pipe(
+						delay(100),
+						tap((v) => logs.push(v)),
+					);
+				});
+
+				expect(s()).toEqual(null); // initial value
+				TestBed.flushEffects();
+				expect(s()).toEqual(null); // initial value
+				tick(100); // wait 100ms for promise to resolve
+				expect(s()).toEqual(1);
+				expect(logs).toEqual([1]);
+
+				value.set(2);
+				TestBed.flushEffects();
+				expect(s()).toEqual(1); // still the old value
+				tick(100); // wait 100ms for promise to resolve
+				expect(s()).toEqual(2);
+				expect(logs).toEqual([1, 2]);
+			});
+		}));
+		it('cancels previous computation', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const logs: number[] = [];
+				const value = signal(1);
+
+				const s = computedAsync(() => {
+					return of(value()).pipe(
+						delay(100),
+						tap((v) => logs.push(v)),
+					);
+				});
+
+				expect(s()).toEqual(null); // initial value
+				TestBed.flushEffects();
+				expect(s()).toEqual(null); // initial value
+				tick(100); // wait 100ms for promise to resolve
+				expect(s()).toEqual(1);
+				expect(logs).toEqual([1]);
+
+				value.set(2);
+				TestBed.flushEffects();
+				expect(s()).toEqual(1); // still the old value
+
+				tick(50); // wait 50ms
+
+				expect(s()).toEqual(1);
+				expect(logs).toEqual([1]);
+
+				value.set(3);
+				TestBed.flushEffects();
+
+				tick(50); // wait 50ms
+				expect(s()).toEqual(1);
+				expect(logs).toEqual([1]);
+
+				tick(50); // wait 50ms
+				expect(s()).toEqual(3);
+				expect(logs).toEqual([1, 3]);
+
+				// 2 was skipped -> the computation was cancelled
+			});
+		}));
+	});
+});

--- a/libs/ngxtension/computed-async/src/computed-async.spec.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.spec.ts
@@ -1,5 +1,5 @@
-import { signal } from '@angular/core';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Signal, signal } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { delay, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { computedAsync } from './computed-async';
@@ -154,5 +154,38 @@ describe(computedAsync.name, () => {
 				// 2 was skipped -> the computation was cancelled
 			});
 		}));
+	});
+
+	describe('is typesafe', () => {
+		it('initial value', () => {
+			const a: Signal<number> = computedAsync(() => {
+				if (Math.random() > 0.5) return Promise.resolve(1);
+				return Promise.resolve(1);
+			});
+
+			const b: Signal<number> = computedAsync(() => {
+				if (Math.random() > 0.5) return of(1);
+				return of(1);
+			});
+
+			const c: Signal<number | null> = computedAsync(
+				() => {
+					return 1;
+				},
+				{ initialValue: null },
+			);
+
+			const d: Signal<string> = computedAsync(
+				() => {
+					return '';
+				},
+				{ initialValue: '' },
+			);
+
+			expect(a).toBeTruthy();
+			expect(b).toBeTruthy();
+			expect(c).toBeTruthy();
+			expect(d).toBeTruthy();
+		});
 	});
 });

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -116,7 +116,6 @@ export function computedAsync<T>(
 			error: (error) => {
 				// NOTE: Error should be handled by the user (using catchError or .catch())
 				sourceValue.set(error);
-				throw error;
 			},
 		});
 

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -13,11 +13,11 @@ import { assertInjector } from 'ngxtension/assert-injector';
 import {
 	Observable,
 	Subject,
-	concatMap,
-	exhaustMap,
+	concatAll,
+	exhaustAll,
 	isObservable,
-	mergeMap,
-	switchMap,
+	mergeAll,
+	switchAll,
 } from 'rxjs';
 
 type ComputedAsyncBehavior = 'switch' | 'merge' | 'concat' | 'exhaust';
@@ -141,16 +141,14 @@ function createFlattenObservable<T>(
 	source: Subject<Promise<T> | Observable<T>>,
 	behavior: ComputedAsyncBehavior,
 ): Observable<T> {
-	switch (behavior) {
-		case 'merge':
-			return source.pipe(mergeMap((s) => s));
-		case 'concat':
-			return source.pipe(concatMap((s) => s));
-		case 'exhaust':
-			return source.pipe(exhaustMap((s) => s));
-		default: // switch
-			return source.pipe(switchMap((s) => s));
-	}
+	const KEY_OPERATOR_MAP = {
+		merge: mergeAll,
+		concat: concatAll,
+		exhaust: exhaustAll,
+		switch: switchAll,
+	};
+
+	return source.pipe(KEY_OPERATOR_MAP[behavior]());
 }
 
 function isPromise<T>(value: any): value is Promise<T> {

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -94,14 +94,14 @@ export function computedAsync<T>(
 				const currentValue = untracked(() => sourceValue());
 
 				const newSource = computation(currentValue);
+
 				if (!isObservable(newSource) && !isPromise(newSource)) {
 					// if the new source is not an observable or a promise, we set the value immediately
 					untracked(() => sourceValue.set(newSource));
-					return;
+				} else {
+					// we untrack the source$.next() so that we don't register other signals as dependencies
+					untracked(() => sourceEvent$.next(newSource));
 				}
-
-				// we untrack the source$.next() so that we don't register other signals as dependencies
-				untracked(() => sourceEvent$.next(newSource));
 			},
 			{ injector: options?.injector },
 		);

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -1,0 +1,59 @@
+import {
+	DestroyRef,
+	Injector,
+	computed,
+	effect,
+	inject,
+	signal,
+	untracked,
+	type CreateComputedOptions,
+} from '@angular/core';
+import { assertInjector } from 'ngxtension/assert-injector';
+import { Observable, Subject, isObservable, switchMap } from 'rxjs';
+
+export function computedAsync<T>(
+	computation: () => Promise<T> | Observable<T> | null | undefined,
+	options?:
+		| (CreateComputedOptions<void> & { initialValue?: T; injector?: Injector })
+		| undefined,
+) {
+	return assertInjector(computedAsync, options?.injector, () => {
+		const destroyRef = inject(DestroyRef);
+
+		const source$ = new Subject<Promise<T> | Observable<T>>();
+
+		const effectRef = effect(
+			() => {
+				const newSource = computation();
+				if (!isObservable(newSource) && !isPromise(newSource)) return;
+				untracked(() => source$.next(newSource));
+			},
+			{ injector: options?.injector },
+		);
+
+		const sourceValue = signal<T | null>(options?.initialValue ?? null);
+
+		const sourceResult = source$
+			.pipe(switchMap((source$) => source$))
+			.subscribe({
+				next: (value) => {
+					sourceValue.set(value);
+				},
+				error: (error) => {
+					sourceValue.set(null);
+					throw error;
+				},
+			});
+
+		destroyRef.onDestroy(() => {
+			effectRef.destroy();
+			sourceResult.unsubscribe();
+		});
+
+		return computed(() => sourceValue(), { equal: options?.equal });
+	});
+}
+
+function isPromise<T>(value: any): value is Promise<T> {
+	return value && typeof value.then === 'function';
+}

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -11,6 +11,31 @@ import {
 import { assertInjector } from 'ngxtension/assert-injector';
 import { Observable, Subject, isObservable, switchMap } from 'rxjs';
 
+/**
+ * A computed value that can be async! This is useful for when you need to compute a value based on a Promise or Observable.
+ *
+ * @example
+ * ```ts
+ * const value = computedAsync(() =>
+ *   fetch(`https://localhost/api/people/${this.userId()}`).then(r => r.json())
+ * );
+ * ```
+ *
+ * The computed value will be `null` until the promise resolves.
+ * Everytime the userId changes, the fetch will be called again, and the previous fetch will be cancelled.
+ * If the promise rejects, the error will be thrown.
+ *
+ * It can also be used with Observables:
+ *
+ * ```ts
+ * const value = computedAsync(() =>
+ *  this.http.get(`https://localhost/api/people/${this.userId()}`)
+ * );
+ * ```
+ *
+ * @param computation
+ * @param options
+ */
 export function computedAsync<T>(
 	computation: () => Promise<T> | Observable<T> | T | null,
 	options?:
@@ -20,29 +45,36 @@ export function computedAsync<T>(
 	return assertInjector(computedAsync, options?.injector, () => {
 		const destroyRef = inject(DestroyRef);
 
+		// source$ is a Subject that will emit the new source value
 		const source$ = new Subject<Promise<T> | Observable<T>>();
+
+		// will hold the current value
 		const sourceValue = signal<T | null>(options?.initialValue ?? null);
 
 		const effectRef = effect(
 			() => {
 				const newSource = computation();
 				if (!isObservable(newSource) && !isPromise(newSource)) {
-					// set the value directly
+					// if the new source is not an observable or a promise, we set the value immediately
 					sourceValue.set(newSource);
 					return;
 				}
+
+				// we untrack the source$.next() so that we don't register other signals as dependencies
 				untracked(() => source$.next(newSource));
 			},
-			{ injector: options?.injector },
+			{ injector: options?.injector, allowSignalWrites: true },
 		);
 
 		const sourceResult = source$
-			.pipe(switchMap((source$) => source$))
+			// we switchMap to the new source so that we cancel the previous source
+			.pipe(switchMap((s) => s))
 			.subscribe({
 				next: (value) => {
 					sourceValue.set(value);
 				},
 				error: (error) => {
+					// TODO: should we set the value to null here?
 					sourceValue.set(null);
 					throw error;
 				},
@@ -53,6 +85,8 @@ export function computedAsync<T>(
 			sourceResult.unsubscribe();
 		});
 
+		// we return a computed value that will return the current value
+		// in order to support the same API as computed()
 		return computed(() => sourceValue(), { equal: options?.equal });
 	});
 }

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -10,11 +10,22 @@ import {
 	type Signal,
 } from '@angular/core';
 import { assertInjector } from 'ngxtension/assert-injector';
-import { Observable, Subject, isObservable, switchMap } from 'rxjs';
+import {
+	Observable,
+	Subject,
+	concatMap,
+	exhaustMap,
+	isObservable,
+	mergeMap,
+	switchMap,
+} from 'rxjs';
+
+export type ComputedAsyncBehavior = 'switch' | 'merge' | 'concat' | 'exhaust';
 
 interface ComputedAsyncOptions<T> extends CreateComputedOptions<void> {
 	initialValue?: T;
 	injector?: Injector;
+	behavior?: ComputedAsyncBehavior;
 }
 
 export function computedAsync<T>(
@@ -33,7 +44,7 @@ export function computedAsync<T>(
  * ```
  *
  * The computed value will be `null` until the promise resolves.
- * Everytime the userId changes, the fetch will be called again, and the previous fetch will be cancelled.
+ * Everytime the userId changes, the fetch will be called again, and the previous fetch will be cancelled (it uses switchMap by default).
  * If the promise rejects, the error will be thrown.
  *
  * It can also be used with Observables:
@@ -44,20 +55,35 @@ export function computedAsync<T>(
  * );
  * ```
  *
+ * You can also pass an `initialValue` option to set the initial value of the computed value.
+ *
+ * ```ts
+ * const userTasks = computedAsync(() =>
+ *   this.http.get(`https://localhost/api/tasks?userId=${this.userId()}`),
+ *   { initialValue: [] }
+ * );
+ * ```
+ *
+ * You can also pass a `behavior` option to change the behavior of the computed value.
+ * - `switch` (default): will cancel the previous computation when a new one is triggered
+ * - `merge`: will use `mergeMap` to merge the last observable with the new one
+ * - `concat`: will use `concatMap` to concat the last observable with the new one
+ * - `exhaust`: will use `exhaustMap` to skip all the new emissions until the last observable completes
+ *
+ * You can also pass an `injector` option if you want to use it outside of the injection context.
+ *
  * @param computation
  * @param options
  */
 export function computedAsync<T>(
 	computation: () => Promise<T> | Observable<T> | T | null,
-	options?:
-		| (CreateComputedOptions<void> & { initialValue?: T; injector?: Injector })
-		| undefined,
+	options: ComputedAsyncOptions<T> | undefined = { behavior: 'switch' },
 ) {
 	return assertInjector(computedAsync, options?.injector, () => {
 		const destroyRef = inject(DestroyRef);
 
 		// source$ is a Subject that will emit the new source value
-		const source$ = new Subject<Promise<T> | Observable<T>>();
+		const sourceEvent$ = new Subject<Promise<T> | Observable<T>>();
 
 		// will hold the current value
 		const sourceValue = signal<T | null>(options?.initialValue ?? null);
@@ -72,24 +98,24 @@ export function computedAsync<T>(
 				}
 
 				// we untrack the source$.next() so that we don't register other signals as dependencies
-				untracked(() => source$.next(newSource));
+				untracked(() => sourceEvent$.next(newSource));
 			},
 			{ injector: options?.injector },
 		);
 
-		const sourceResult = source$
-			// we switchMap to the new source so that we cancel the previous source
-			.pipe(switchMap((s) => s))
-			.subscribe({
-				next: (value) => {
-					sourceValue.set(value);
-				},
-				error: (error) => {
-					// TODO: should we set the value to null here?
-					sourceValue.set(null);
-					throw error;
-				},
-			});
+		const source$: Observable<T> = createFlattenObservable(
+			sourceEvent$,
+			options?.behavior ?? 'switch',
+		);
+
+		const sourceResult = source$.subscribe({
+			next: (value) => sourceValue.set(value),
+			error: (error) => {
+				// NOTE: Error should be handled by the user (using catchError or .catch())
+				sourceValue.set(error);
+				throw error;
+			},
+		});
 
 		destroyRef.onDestroy(() => {
 			effectRef.destroy();
@@ -100,6 +126,22 @@ export function computedAsync<T>(
 		// in order to support the same API as computed()
 		return computed(() => sourceValue(), { equal: options?.equal });
 	});
+}
+
+function createFlattenObservable<T>(
+	source: Subject<Promise<T> | Observable<T>>,
+	behavior: ComputedAsyncBehavior,
+): Observable<T> {
+	switch (behavior) {
+		case 'merge':
+			return source.pipe(mergeMap((s) => s));
+		case 'concat':
+			return source.pipe(concatMap((s) => s));
+		case 'exhaust':
+			return source.pipe(exhaustMap((s) => s));
+		default: // switch
+			return source.pipe(switchMap((s) => s));
+	}
 }
 
 function isPromise<T>(value: any): value is Promise<T> {

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -7,9 +7,20 @@ import {
 	signal,
 	untracked,
 	type CreateComputedOptions,
+	type Signal,
 } from '@angular/core';
 import { assertInjector } from 'ngxtension/assert-injector';
 import { Observable, Subject, isObservable, switchMap } from 'rxjs';
+
+interface ComputedAsyncOptions<T> extends CreateComputedOptions<void> {
+	initialValue?: T;
+	injector?: Injector;
+}
+
+export function computedAsync<T>(
+	computation: () => Promise<T> | Observable<T> | T | null,
+	options?: ComputedAsyncOptions<T> | undefined,
+): T extends null ? Signal<T | null> : Signal<T>;
 
 /**
  * A computed value that can be async! This is useful for when you need to compute a value based on a Promise or Observable.

--- a/libs/ngxtension/computed-async/src/computed-async.ts
+++ b/libs/ngxtension/computed-async/src/computed-async.ts
@@ -67,14 +67,14 @@ export function computedAsync<T>(
 				const newSource = computation();
 				if (!isObservable(newSource) && !isPromise(newSource)) {
 					// if the new source is not an observable or a promise, we set the value immediately
-					sourceValue.set(newSource);
+					untracked(() => sourceValue.set(newSource));
 					return;
 				}
 
 				// we untrack the source$.next() so that we don't register other signals as dependencies
 				untracked(() => source$.next(newSource));
 			},
-			{ injector: options?.injector, allowSignalWrites: true },
+			{ injector: options?.injector },
 		);
 
 		const sourceResult = source$

--- a/libs/ngxtension/computed-async/src/index.ts
+++ b/libs/ngxtension/computed-async/src/index.ts
@@ -1,0 +1,1 @@
+export { computedAsync } from './computed-async';

--- a/libs/ngxtension/package.json
+++ b/libs/ngxtension/package.json
@@ -26,7 +26,6 @@
 	"dependencies": {
 		"@nx/devkit": "^17.0.0",
 		"nx": "^17.0.0",
-		"ts-morph": "^21.0.0",
 		"tslib": "^2.3.0"
 	},
 	"sideEffects": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,9 @@
 				"libs/ngxtension/click-outside/src/index.ts"
 			],
 			"ngxtension/computed": ["libs/ngxtension/computed/src/index.ts"],
+			"ngxtension/computed-async": [
+				"libs/ngxtension/computed-async/src/index.ts"
+			],
 			"ngxtension/computed-from": [
 				"libs/ngxtension/computed-from/src/index.ts"
 			],


### PR DESCRIPTION
Closes https://github.com/nartc/ngxtension-platform/issues/228 

Can be used as: 

```ts
  private http = inject(HttpClient);

  productId = injectQueryParams('productId');

  product = computedAsync(() => {
    const productId = this.productId();
    if (!productId) return null;

    return this.http.get<{ id: string; title: string }>(`${API}/${productId}`)

  });
```

> Uses `switchMap` to cancel ongoing requests. 

Playground: [https://stackblitz.com/edit/stackblitz-starters-pzxg8a?file=src%2Fcomputed-async.ts,src%2Fmain.ts,src%2Fglobal_styles.css](https://stackblitz.com/edit/stackblitz-starters-pzxg8a?file=src%2Fcomputed-async.ts,src%2Fmain.ts,src%2Fglobal_styles.css)