### PR TITLE
feat: add toObservableSignal()

### DIFF
--- a/docs/src/content/docs/utilities/Signals/to-observable-signal.md
+++ b/docs/src/content/docs/utilities/Signals/to-observable-signal.md
@@ -1,0 +1,48 @@
+---
+title: toObservableSignal
+description: ngxtension/to-observable-signal
+entryPoint: to-observable-signal
+badge: stable
+contributor: evgeniy-oz
+---
+
+`toObservableSignal()` combines the functionality of Angular Signal and RxJS Observable.
+
+This function uses `toObservable()` from `@angular/core/rxjs-interop` under the hood, so it should be called in an injection context, or the `injector` should be passed as the second argument (options).
+
+```ts
+import { toObservableSignal } from 'ngxtension/to-observable-signal';
+```
+
+## Usage
+
+```ts
+@Component({
+	selector: 'my-app',
+	standalone: true,
+	imports: [CommonModule],
+	template: `
+		<h2>Signal A: {{ a() }}</h2>
+		<h2>Observable A: {{ a | async }}</h2>
+		<h2>Observable B (A*2): {{ b | async }}</h2>
+		<h2>Signal C (A*3): {{ c() }}</h2>
+	`,
+})
+export class App {
+	a = toObservableSignal(signal<number>(0));
+	b = this.a.pipe(
+		switchMap((v) => {
+			return of(v * 2);
+		}),
+	);
+	c = computed(() => this.a() * 3);
+
+	constructor() {
+		setInterval(() => this.a.set(1), 10000);
+		setInterval(() => this.a.update((v) => v + 1), 1000);
+	}
+}
+```
+
+`toObservableSignal()` accepts a `Signal` or `WritableSignal` as the first argument.  
+The second argument is optional - it is a `ToObservableOptions` object, which is the exact type used by `toObservable()`. Here, you can set the injector.

--- a/libs/ngxtension/to-observable-signal/README.md
+++ b/libs/ngxtension/to-observable-signal/README.md
@@ -1,0 +1,3 @@
+# ngxtension/to-observable-signal
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/to-observable-signal`.

--- a/libs/ngxtension/to-observable-signal/ng-package.json
+++ b/libs/ngxtension/to-observable-signal/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/to-observable-signal/project.json
+++ b/libs/ngxtension/to-observable-signal/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/to-observable-signal",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/to-observable-signal/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["to-observable-signal"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/to-observable-signal/src/index.ts
+++ b/libs/ngxtension/to-observable-signal/src/index.ts
@@ -1,0 +1,1 @@
+export const greeting = 'Hello World!';

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
@@ -1,0 +1,65 @@
+import { Injector, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { toObservableSignal } from './to-observable-signal';
+
+describe('toObservableSignal()', () => {
+	it('should return a <WritableSignal & Observable> when input is WritableSignal', () => {
+		const s = signal<string>('Hello');
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(s, { injector });
+
+		expect(observableSignal).toEqual(s);
+		expect(observableSignal.subscribe).toBeDefined();
+		expect(observableSignal.pipe).toBeDefined();
+		expect(observableSignal.set).toBeDefined();
+		expect(observableSignal.update).toBeDefined();
+		expect(observableSignal.asReadonly).toBeDefined();
+		expect(typeof observableSignal).toEqual('function');
+		expect(observableSignal()).toEqual('Hello');
+	});
+
+	it('should return an ObservableSignal when input is Signal', () => {
+		const s = signal<string>('Hello').asReadonly();
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(s, { injector });
+
+		expect(observableSignal).toEqual(s);
+		expect(observableSignal.subscribe).toBeDefined();
+		expect(observableSignal.pipe).toBeDefined();
+		expect((observableSignal as any)['set']).toBeUndefined();
+		expect((observableSignal as any)['update']).toBeUndefined();
+		expect((observableSignal as any)['asReadonly']).toBeUndefined();
+		expect(typeof observableSignal).toEqual('function');
+		expect(observableSignal()).toEqual('Hello');
+	});
+
+	it('should emit the value of the original signal as an observable', (done) => {
+		const s = signal<string>('Hello');
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(s, { injector });
+		TestBed.flushEffects();
+
+		observableSignal.subscribe((value) => {
+			done();
+			expect(value).toBe('Hello');
+		});
+	});
+
+	it('should emit the updated value when the original signal changes', (done) => {
+		const s = signal<string>('Hello');
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(s, { injector });
+
+		s.set('World');
+		TestBed.flushEffects();
+
+		observableSignal.subscribe((value) => {
+			expect(value).toBe('World');
+			done();
+		});
+	});
+});

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
@@ -43,8 +43,8 @@ describe('toObservableSignal()', () => {
 		TestBed.flushEffects();
 
 		observableSignal.subscribe((value) => {
-			done();
 			expect(value).toBe('Hello');
+			done();
 		});
 	});
 

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
@@ -1,0 +1,37 @@
+import {
+	assertInInjectionContext,
+	isDevMode,
+	type Signal,
+	type WritableSignal,
+} from '@angular/core';
+import {
+	toObservable,
+	type ToObservableOptions,
+} from '@angular/core/rxjs-interop';
+import type { Observable } from 'rxjs';
+
+export type ObservableSignal<T> = Signal<T> & Observable<T>;
+
+export function toObservableSignal<T>(
+	s: WritableSignal<T>,
+	options?: ToObservableOptions,
+): WritableSignal<T> & Observable<T>;
+export function toObservableSignal<T>(
+	s: Signal<T>,
+	options?: ToObservableOptions,
+): ObservableSignal<T>;
+
+export function toObservableSignal<T>(
+	s: Signal<T>,
+	options?: ToObservableOptions,
+) {
+	if (isDevMode() && !options?.injector) {
+		assertInInjectionContext(toObservableSignal);
+	}
+
+	const obs = toObservable(s, options);
+	for (const obsKey in obs) {
+		(s as any)[obsKey] = (obs as any)[obsKey];
+	}
+	return s;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -93,6 +93,9 @@
 			"ngxtension/to-lazy-signal": [
 				"libs/ngxtension/to-lazy-signal/src/index.ts"
 			],
+			"ngxtension/to-observable-signal": [
+				"libs/ngxtension/to-observable-signal/src/index.ts"
+			],
 			"ngxtension/trackby-id-prop": [
 				"libs/ngxtension/trackby-id-prop/src/index.ts"
 			],


### PR DESCRIPTION
`toObservableSignal()` combines the functionality of Angular Signal and RxJS Observable.

## StackBlitz

https://stackblitz.com/edit/stackblitz-starters-owzm3q?file=src%2Fmain.ts

## Usage

```ts
@Component({
  selector: 'my-app',
  standalone: true,
  imports: [CommonModule],
  template: `
    <h2>Signal A: {{ a() }}</h2>
    <h2>Observable A: {{ a | async }}</h2>
    <h2>Observable B (A*2): {{ b | async }}</h2>
    <h2>Signal C (A*3): {{ c() }}</h2>
  `,
})
export class App {
  a = toObservableSignal(signal<number>(0));
  b = this.a.pipe(
    switchMap((v) => {
      return of(v * 2);
    }),
  );
  c = computed(() => this.a() * 3);
  
  constructor() {
  setInterval(() => this.a.set(1), 10000);
  setInterval(() => this.a.update((v) => v + 1), 1000);
  }
}
```
