### PR TITLE
fix: correct export for toObservableSignal feature

### DIFF
--- a/libs/ngxtension/to-observable-signal/src/index.ts
+++ b/libs/ngxtension/to-observable-signal/src/index.ts
@@ -1,1 +1,4 @@
-export const greeting = 'Hello World!';
+export {
+	toObservableSignal,
+	type ObservableSignal,
+} from './to-observable-signal';


### PR DESCRIPTION
I made a stupid mistake and forgot to export in index.ts