### PR TITLE
fix(connect): update literal object values correctly for non-literal object values

### DIFF
--- a/libs/ngxtension/connect/src/connect.spec.ts
+++ b/libs/ngxtension/connect/src/connect.spec.ts
@@ -63,6 +63,7 @@ describe(connect.name, () => {
 			source$ = new Subject<number>();
 
 			objectSignal = signal<any>({});
+			reducerSignal = signal<any>({});
 			objectSource$ = new Subject<any>();
 
 			// this works too
@@ -71,6 +72,9 @@ describe(connect.name, () => {
 			constructor() {
 				connect(this.count, this.source$.pipe(take(2)));
 				connect(this.objectSignal, this.objectSource$);
+				connect(this.reducerSignal, this.objectSource$, (_, curr) => {
+					return curr;
+				});
 			}
 		}
 
@@ -95,7 +99,7 @@ describe(connect.name, () => {
 			expect(component.count()).toBe(2); // should not change because we only took 2 values
 		});
 
-		it('correctly updates from object values', () => {
+		it('correctly updates from literal object values to non-literal object values', () => {
 			component.objectSource$.next(null);
 			expect(component.objectSignal()).toEqual(null);
 
@@ -116,6 +120,11 @@ describe(connect.name, () => {
 			component.objectSource$.next({});
 			component.objectSource$.next([]);
 			expect(component.objectSignal()).toEqual([]);
+		});
+
+		it('correctly updates from object literal object values with reducer', () => {
+			component.objectSource$.next(null);
+			expect(component.reducerSignal()).toEqual(null);
 		});
 	});
 

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -116,20 +116,16 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 		return observable.pipe(takeUntilDestroyed(destroyRef)).subscribe((x) => {
 			const update = () => {
 				signal.update((prev) => {
-					if (isObject(prev)) {
-						if (!isObject(x)) {
-							if (reducer) {
-								const reducedValue = reducer(prev, x);
-								return isObject(reducedValue)
-									? { ...prev, ...(reducedValue as object) }
-									: reducedValue;
-							}
-							return x;
-						} else {
-							return { ...prev, ...((reducer?.(prev, x) || x) as object) };
-						}
+					if (!isObject(prev)) return reducer?.(prev, x) || x;
+
+					if (!isObject(x)) {
+						const reducedValue = reducer ? reducer(prev, x) : x;
+						return isObject(reducedValue)
+							? { ...prev, ...(reducedValue as object) }
+							: reducedValue;
 					}
-					return reducer?.(prev, x) || x;
+
+					return { ...prev, ...((reducer?.(prev, x) || x) as object) };
 				});
 			};
 

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -118,7 +118,13 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 				signal.update((prev) => {
 					if (isObject(prev)) {
 						if (!isObject(x)) {
-							return reducer ? { ...prev, ...(reducer(prev, x) as object) } : x;
+							if (reducer) {
+								const reducedValue = reducer(prev, x);
+								return isObject(reducedValue)
+									? { ...prev, ...(reducedValue as object) }
+									: reducedValue;
+							}
+							return x;
 						} else {
 							return { ...prev, ...((reducer?.(prev, x) || x) as object) };
 						}

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -116,15 +116,13 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 		return observable.pipe(takeUntilDestroyed(destroyRef)).subscribe((x) => {
 			const update = () => {
 				signal.update((prev) => {
-					if (
-						prev !== undefined &&
-						prev !== null &&
-						typeof prev === 'object' &&
-						!Array.isArray(prev)
-					) {
-						return { ...prev, ...((reducer?.(prev, x) || x) as object) };
+					if (isObject(prev)) {
+						if (!isObject(x)) {
+							return reducer ? { ...prev, ...(reducer(prev, x) as object) } : x;
+						} else {
+							return { ...prev, ...((reducer?.(prev, x) || x) as object) };
+						}
 					}
-
 					return reducer?.(prev, x) || x;
 				});
 			};
@@ -244,4 +242,13 @@ function parseArgs(
 	}
 
 	return [null, null, args[0] as Injector | DestroyRef, false, null];
+}
+
+function isObject(val: any): val is object {
+	return (
+		typeof val === 'object' &&
+		val !== undefined &&
+		val !== null &&
+		!Array.isArray(val)
+	);
 }

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -116,7 +116,9 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 		return observable.pipe(takeUntilDestroyed(destroyRef)).subscribe((x) => {
 			const update = () => {
 				signal.update((prev) => {
-					if (!isObject(prev)) return reducer?.(prev, x) || x;
+					if (!isObject(prev)) {
+						return reducer?.(prev, x) || x;
+					}
 
 					if (!isObject(x)) {
 						const reducedValue = reducer ? reducer(prev, x) : x;


### PR DESCRIPTION
This fixes an issue where the signal would not be updated correctly when a non-literal object value is used to update a literal object value.

For example, attempting to update `{}` with `null` would result in the value still being `{}`