### PR TITLE
feat(create-injectable): add createInjectable (replaces createService)

### DIFF
--- a/docs/src/content/docs/utilities/Injectors/create-injectable.md
+++ b/docs/src/content/docs/utilities/Injectors/create-injectable.md
@@ -19,9 +19,24 @@ configuration.
 
 ## Usage
 
+### Shared Service
+
 ```ts
-// defining a service
-export const MyService = createInjectable(
+// defining a shared service
+export const [MyService] = createInjectable(() => {
+	const myState = signal(1);
+
+	return { myState: myState.asReadonly() };
+});
+
+// using the service
+const myService = inject(MyService);
+```
+
+### Non-root Service
+
+```ts
+export const [MyService, provideMyService] = createInjectable(
 	() => {
 		const myState = signal(1);
 
@@ -29,7 +44,14 @@ export const MyService = createInjectable(
 	},
 	{ isRoot: false },
 );
+```
 
-// using a service
+```ts
+{
+	providers: [provideMyService()];
+}
+```
+
+```ts
 const myService = inject(MyService);
 ```

--- a/docs/src/content/docs/utilities/Injectors/create-injectable.md
+++ b/docs/src/content/docs/utilities/Injectors/create-injectable.md
@@ -6,52 +6,54 @@ badge: experimental
 contributor: josh-morony
 ---
 
-`createInjectable` uses `createInjectionToken` behind the scenes as a way to
-create injectable services and other types of injectables in Angular without
-using classes and decorators.
+`createInjectable` returns a class behind the scenes as a way to
+create injectable services and other types of injectables in Angular without using classes and decorators.
 
 The general difference is that rather than using a class, we use a `function` to
 create the injectable. Whatever the function returns is what will be the
 consumable public API of the service, everything else will be private.
 
-To create an injectable that is `providedIn: 'root'` you can omit the `isRoot`
-configuration.
+Pass `{ providedIn: 'root' }` to the 2nd argument of `createInjectable` if you want to create a root service.
 
 ## Usage
-
-### Shared Service
-
-```ts
-// defining a shared service
-export const [MyService] = createInjectable(() => {
-	const myState = signal(1);
-
-	return { myState: myState.asReadonly() };
-});
-
-// using the service
-const myService = inject(MyService);
-```
 
 ### Non-root Service
 
 ```ts
-export const [MyService, provideMyService] = createInjectable(
-	() => {
-		const myState = signal(1);
+// defining a service
+export const MyService = createInjectable(() => {
+	const myState = signal(1);
 
-		return { myState: myState.asReadonly() };
-	},
-	{ isRoot: false },
-);
+	return { myState: myState.asReadonly() };
+});
 ```
 
 ```ts
+// provide the service
 {
-	providers: [provideMyService()];
+	providers: [MyService];
 }
 ```
 
 ```ts
+// using the service
+const myService = inject(MyService);
+```
+
+### Root Service
+
+```ts
+// defining a root service
+export const MyService = createInjectable(
+	() => {
+		const myState = signal(1);
+		return { myState: myState.asReadonly() };
+	},
+	{ providedIn: 'root' },
+);
+```
+
+```ts
+// using the service
 const myService = inject(MyService);
 ```

--- a/docs/src/content/docs/utilities/Injectors/create-injectable.md
+++ b/docs/src/content/docs/utilities/Injectors/create-injectable.md
@@ -1,0 +1,35 @@
+---
+title: createInjectable
+description: A function based approach for creating Injectable services
+entryPoint: create-injectable
+badge: experimental
+contributor: josh-morony
+---
+
+`createInjectable` uses `createInjectionToken` behind the scenes as a way to
+create injectable services and other types of injectables in Angular without
+using classes and decorators.
+
+The general difference is that rather than using a class, we use a `function` to
+create the injectable. Whatever the function returns is what will be the
+consumable public API of the service, everything else will be private.
+
+To create an injectable that is `providedIn: 'root'` you can omit the `isRoot`
+configuration.
+
+## Usage
+
+```ts
+// defining a service
+export const MyService = createInjectable(
+	() => {
+		const myState = signal(1);
+
+		return { myState: myState.asReadonly() };
+	},
+	{ isRoot: false },
+);
+
+// using a service
+const myService = inject(MyService);
+```

--- a/docs/src/content/docs/utilities/Injectors/create-injectable.md
+++ b/docs/src/content/docs/utilities/Injectors/create-injectable.md
@@ -3,7 +3,7 @@ title: createInjectable
 description: A function based approach for creating Injectable services
 entryPoint: create-injectable
 badge: experimental
-contributor: josh-morony
+contributor: chau-tran
 ---
 
 `createInjectable` returns a class behind the scenes as a way to

--- a/docs/src/content/docs/utilities/Injectors/create-injectable.md
+++ b/docs/src/content/docs/utilities/Injectors/create-injectable.md
@@ -3,7 +3,7 @@ title: createInjectable
 description: A function based approach for creating Injectable services
 entryPoint: create-injectable
 badge: experimental
-contributor: chau-tran
+contributor: josh-morony
 ---
 
 `createInjectable` returns a class behind the scenes as a way to

--- a/libs/ngxtension/create-injectable/README.md
+++ b/libs/ngxtension/create-injectable/README.md
@@ -1,0 +1,3 @@
+# ngxtension/create-injectable
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/create-injectable`.

--- a/libs/ngxtension/create-injectable/ng-package.json
+++ b/libs/ngxtension/create-injectable/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/create-injectable/project.json
+++ b/libs/ngxtension/create-injectable/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/create-injectable",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/create-injectable/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["create-injectable"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -4,11 +4,27 @@ import { createInjectable } from './create-injectable';
 
 describe(createInjectable.name, () => {
 	it('should be able to access property returned from injectable', () => {
-		const MyInjectable = createInjectable(() => {
+		const [MyInjectable] = createInjectable(() => {
 			return { someProp: 1 };
 		});
 
 		TestBed.runInInjectionContext(() => {
+			const service = inject(MyInjectable);
+			expect(service.someProp).toEqual(1);
+		});
+	});
+
+	it('should be able to provide non-root injectable', () => {
+		const [MyInjectable, provideMyInjectable] = createInjectable(
+			() => {
+				return { someProp: 1 };
+			},
+			{ isRoot: false },
+		);
+
+		TestBed.configureTestingModule({
+			providers: [provideMyInjectable()],
+		}).runInInjectionContext(() => {
 			const service = inject(MyInjectable);
 			expect(service.someProp).toEqual(1);
 		});

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { createInjectable } from './create-injectable';
+
+describe(createInjectable.name, () => {
+	it('should be able to access property returned from injectable', () => {
+		const MyInjectable = createInjectable(() => {
+			return { someProp: 1 };
+		});
+
+		TestBed.runInInjectionContext(() => {
+			const service = inject(MyInjectable);
+			expect(service.someProp).toEqual(1);
+		});
+	});
+});

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -24,8 +24,6 @@ describe(createInjectable.name, () => {
 		});
 
 		TestBed.runInInjectionContext(() => {
-			// should be lazy until `inject()` is invoked
-			expect(count).toEqual(0);
 			const service = inject(MyInjectable);
 			// should still be 1 after `inject` because it is a singleton
 			expect(count).toEqual(1);

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -19,6 +19,18 @@ describe(createInjectable.name, () => {
 			const service = inject(MyInjectable);
 			expect(count).toEqual(1);
 			expect(service.someProp).toEqual(1);
+			// increment prop
+			service.someProp += 1;
+		});
+
+		TestBed.runInInjectionContext(() => {
+			// should be lazy until `inject()` is invoked
+			expect(count).toEqual(0);
+			const service = inject(MyInjectable);
+			// should still be 1 after `inject` because it is a singleton
+			expect(count).toEqual(1);
+			// should be 2 because previous test incremented it
+			expect(service.someProp).toEqual(2);
 		});
 	});
 
@@ -37,6 +49,19 @@ describe(createInjectable.name, () => {
 			const service = inject(MyInjectable);
 			expect(count).toEqual(1);
 			expect(service.someProp).toEqual(1);
+			service.someProp += 1;
 		});
+
+		TestBed.resetTestingModule()
+			.configureTestingModule({ providers: [MyInjectable] })
+			.runInInjectionContext(() => {
+				// should be 1 before `inject`
+				expect(count).toEqual(1);
+				const service = inject(MyInjectable);
+				// should be 2 after `inject` because it is not a singleton
+				expect(count).toEqual(2);
+				// should equal 1 because it is not a singleton
+				expect(service.someProp).toEqual(1);
+			});
 	});
 });

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -4,8 +4,8 @@ import { createInjectable } from './create-injectable';
 
 describe(createInjectable.name, () => {
 	it('should be able to access property returned from injectable', () => {
-		const [MyInjectable] = createInjectable(() => {
-			return { someProp: 1 };
+		const MyInjectable = createInjectable(() => ({ someProp: 1 }), {
+			providedIn: 'root',
 		});
 
 		TestBed.runInInjectionContext(() => {
@@ -15,15 +15,10 @@ describe(createInjectable.name, () => {
 	});
 
 	it('should be able to provide non-root injectable', () => {
-		const [MyInjectable, provideMyInjectable] = createInjectable(
-			() => {
-				return { someProp: 1 };
-			},
-			{ isRoot: false },
-		);
+		const MyInjectable = createInjectable(() => ({ someProp: 1 }));
 
 		TestBed.configureTestingModule({
-			providers: [provideMyInjectable()],
+			providers: [MyInjectable],
 		}).runInInjectionContext(() => {
 			const service = inject(MyInjectable);
 			expect(service.someProp).toEqual(1);

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -4,23 +4,38 @@ import { createInjectable } from './create-injectable';
 
 describe(createInjectable.name, () => {
 	it('should be able to access property returned from injectable', () => {
-		const MyInjectable = createInjectable(() => ({ someProp: 1 }), {
-			providedIn: 'root',
-		});
+		let count = 0;
+		const MyInjectable = createInjectable(
+			() => {
+				count += 1;
+				return { someProp: 1 };
+			},
+			{ providedIn: 'root' },
+		);
 
 		TestBed.runInInjectionContext(() => {
+			// should be lazy until `inject()` is invoked
+			expect(count).toEqual(0);
 			const service = inject(MyInjectable);
+			expect(count).toEqual(1);
 			expect(service.someProp).toEqual(1);
 		});
 	});
 
 	it('should be able to provide non-root injectable', () => {
-		const MyInjectable = createInjectable(() => ({ someProp: 1 }));
+		let count = 0;
+		const MyInjectable = createInjectable(() => {
+			count += 1;
+			return { someProp: 1 };
+		});
 
 		TestBed.configureTestingModule({
 			providers: [MyInjectable],
 		}).runInInjectionContext(() => {
+			// should still be lazy until `inject()` is invoked
+			expect(count).toEqual(0);
 			const service = inject(MyInjectable);
+			expect(count).toEqual(1);
 			expect(service.someProp).toEqual(1);
 		});
 	});

--- a/libs/ngxtension/create-injectable/src/create-injectable.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.ts
@@ -1,0 +1,32 @@
+import {
+	InjectionToken,
+	type EnvironmentProviders,
+	type Provider,
+} from '@angular/core';
+import {
+	createInjectionToken,
+	type CreateInjectionTokenDeps,
+	type CreateInjectionTokenOptions,
+} from 'ngxtension/create-injection-token';
+
+export type CreateInjectableOptions<
+	TFactory extends (...args: any[]) => object,
+	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
+> = (TFactoryDeps[0] extends undefined
+	? { deps?: never }
+	: { deps: CreateInjectionTokenDeps<TFactory, TFactoryDeps> }) & {
+	isRoot?: boolean;
+	token?: InjectionToken<ReturnType<TFactory>>;
+	extraProviders?: Provider | EnvironmentProviders;
+};
+
+export function createInjectable<
+	TFactory extends (...args: any[]) => object,
+	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
+	TOptions extends CreateInjectionTokenOptions<
+		TFactory,
+		TFactoryDeps
+	> = CreateInjectableOptions<TFactory, TFactoryDeps>,
+>(factory: TFactory, options?: TOptions): InjectionToken<ReturnType<TFactory>> {
+	return createInjectionToken(factory, options)[2];
+}

--- a/libs/ngxtension/create-injectable/src/create-injectable.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.ts
@@ -7,6 +7,7 @@ import {
 	createInjectionToken,
 	type CreateInjectionTokenDeps,
 	type CreateInjectionTokenOptions,
+	type ProvideFn,
 } from 'ngxtension/create-injection-token';
 
 export type CreateInjectableOptions<
@@ -20,13 +21,22 @@ export type CreateInjectableOptions<
 	extraProviders?: Provider | EnvironmentProviders;
 };
 
+type CreateInjectableReturn<TFactoryReturn> = [
+	InjectionToken<TFactoryReturn>,
+	ProvideFn<false, TFactoryReturn>,
+];
+
 export function createInjectable<
-	TFactory extends (...args: any[]) => object,
+	TFactory extends (...args: any[]) => any,
 	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
 	TOptions extends CreateInjectionTokenOptions<
 		TFactory,
 		TFactoryDeps
 	> = CreateInjectableOptions<TFactory, TFactoryDeps>,
->(factory: TFactory, options?: TOptions): InjectionToken<ReturnType<TFactory>> {
-	return createInjectionToken(factory, options)[2];
+>(
+	factory: TFactory,
+	options?: TOptions,
+): CreateInjectableReturn<ReturnType<TFactory>> {
+	const [, provideFn, token] = createInjectionToken(factory, options);
+	return [token, provideFn];
 }

--- a/libs/ngxtension/create-injectable/src/create-injectable.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.ts
@@ -1,42 +1,15 @@
-import {
-	InjectionToken,
-	type EnvironmentProviders,
-	type Provider,
-} from '@angular/core';
-import {
-	createInjectionToken,
-	type CreateInjectionTokenDeps,
-	type CreateInjectionTokenOptions,
-	type ProvideFn,
-} from 'ngxtension/create-injection-token';
+import { Injectable, type Type } from '@angular/core';
 
-export type CreateInjectableOptions<
-	TFactory extends (...args: any[]) => object,
-	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
-> = (TFactoryDeps[0] extends undefined
-	? { deps?: never }
-	: { deps: CreateInjectionTokenDeps<TFactory, TFactoryDeps> }) & {
-	isRoot?: boolean;
-	token?: InjectionToken<ReturnType<TFactory>>;
-	extraProviders?: Provider | EnvironmentProviders;
-};
-
-type CreateInjectableReturn<TFactoryReturn> = [
-	InjectionToken<TFactoryReturn>,
-	ProvideFn<false, TFactoryReturn>,
-];
-
-export function createInjectable<
-	TFactory extends (...args: any[]) => any,
-	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
-	TOptions extends CreateInjectionTokenOptions<
-		TFactory,
-		TFactoryDeps
-	> = CreateInjectableOptions<TFactory, TFactoryDeps>,
->(
+export function createInjectable<TFactory extends (...args: any[]) => object>(
 	factory: TFactory,
-	options?: TOptions,
-): CreateInjectableReturn<ReturnType<TFactory>> {
-	const [, provideFn, token] = createInjectionToken(factory, options);
-	return [token, provideFn];
+	{ providedIn }: { providedIn?: 'root' } = {},
+): Type<ReturnType<TFactory>> {
+	@Injectable({ providedIn: providedIn || null })
+	class _Injectable {
+		constructor() {
+			Object.assign(this, factory());
+		}
+	}
+
+	return _Injectable as Type<ReturnType<TFactory>>;
 }

--- a/libs/ngxtension/create-injectable/src/index.ts
+++ b/libs/ngxtension/create-injectable/src/index.ts
@@ -1,0 +1,1 @@
+export * from './create-injectable';

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.spec.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.spec.ts
@@ -3,7 +3,6 @@ import { TestBed } from '@angular/core/testing';
 import {
 	createInjectionToken,
 	createNoopInjectionToken,
-	createService,
 } from './create-injection-token';
 
 describe(createInjectionToken.name, () => {
@@ -178,19 +177,6 @@ describe(createNoopInjectionToken.name, () => {
 				const values = injectFn();
 				expect(values).toEqual([1, 2]);
 			});
-		});
-	});
-});
-
-describe(createService.name, () => {
-	it('should be able to access property returned from service', () => {
-		const [injectFn] = createService(() => {
-			return { someProp: 1 };
-		});
-
-		TestBed.runInInjectionContext(() => {
-			const service = injectFn();
-			expect(service.someProp).toEqual(1);
 		});
 	});
 });

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.ts
@@ -22,7 +22,7 @@ type CreateInjectionTokenDep<TTokenType> =
 	| (abstract new (...args: any[]) => TTokenType)
 	| InjectionToken<TTokenType>;
 
-type CreateInjectionTokenDeps<
+export type CreateInjectionTokenDeps<
 	TFactory extends (...args: any[]) => any,
 	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
 > = {
@@ -47,17 +47,6 @@ export type CreateInjectionTokenOptions<
 		token?: InjectionToken<ReturnType<TFactory>>;
 		extraProviders?: Provider | EnvironmentProviders;
 	};
-
-export type CreateServiceOptions<
-	TFactory extends (...args: any[]) => object,
-	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
-> = (TFactoryDeps[0] extends undefined
-	? { deps?: never }
-	: { deps: CreateInjectionTokenDeps<TFactory, TFactoryDeps> }) & {
-	isRoot?: boolean;
-	token?: InjectionToken<ReturnType<TFactory>>;
-	extraProviders?: Provider | EnvironmentProviders;
-};
 
 type CreateProvideFnOptions<
 	TFactory extends (...args: any[]) => any,
@@ -272,18 +261,4 @@ export function createNoopInjectionToken<
 		token,
 		() => {},
 	] as CreateInjectionTokenReturn<TReturn, true>;
-}
-
-export function createService<
-	TFactory extends (...args: any[]) => object,
-	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
-	TOptions extends CreateInjectionTokenOptions<
-		TFactory,
-		TFactoryDeps
-	> = CreateServiceOptions<TFactory, TFactoryDeps>,
->(
-	factory: TFactory,
-	options?: TOptions,
-): CreateInjectionTokenReturn<ReturnType<TFactory>> {
-	return createInjectionToken(factory, options);
 }

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.ts
@@ -68,7 +68,7 @@ type InjectFn<TFactoryReturn> = {
 	): TFactoryReturn | null;
 };
 
-type ProvideFn<
+export type ProvideFn<
 	TNoop extends boolean,
 	TFactoryReturn,
 	TReturn = TFactoryReturn extends Array<infer Item> ? Item : TFactoryReturn,

--- a/libs/ngxtension/create-injection-token/src/create-injection-token.ts
+++ b/libs/ngxtension/create-injection-token/src/create-injection-token.ts
@@ -22,7 +22,7 @@ type CreateInjectionTokenDep<TTokenType> =
 	| (abstract new (...args: any[]) => TTokenType)
 	| InjectionToken<TTokenType>;
 
-export type CreateInjectionTokenDeps<
+type CreateInjectionTokenDeps<
 	TFactory extends (...args: any[]) => any,
 	TFactoryDeps extends Parameters<TFactory> = Parameters<TFactory>,
 > = {
@@ -68,7 +68,7 @@ type InjectFn<TFactoryReturn> = {
 	): TFactoryReturn | null;
 };
 
-export type ProvideFn<
+type ProvideFn<
 	TNoop extends boolean,
 	TFactoryReturn,
 	TReturn = TFactoryReturn extends Array<infer Item> ? Item : TFactoryReturn,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,9 @@
 			"ngxtension/create-effect": [
 				"libs/ngxtension/create-effect/src/index.ts"
 			],
+			"ngxtension/create-injectable": [
+				"libs/ngxtension/create-injectable/src/index.ts"
+			],
 			"ngxtension/create-injection-token": [
 				"libs/ngxtension/create-injection-token/src/index.ts"
 			],


### PR DESCRIPTION
Discussion: https://twitter.com/spierala/status/1748639069171568771

This PR removes the undocumented `createService` function added to the `create-injection-token` entry point in favour of:

1) Moving it to its own entry point
2) Renaming it to `createInjectable`
3) Having it return injectable directly instead of the injectFn/provideFn/token tuple that `createInjectionToken` returns by default

I've marked this as experimental for now to give us some flexibility in potential changes

EDIT: Updated usage based on updates from @nartc 

## Non-root Service

```ts
// defining a service
export const MyService = createInjectable(() => {
	const myState = signal(1);

	return { myState: myState.asReadonly() };
});
```

```ts
// provide the service
{
	providers: [MyService];
}
```

```ts
// using the service
const myService = inject(MyService);
```

## Root Service

```ts
// defining a root service
export const MyService = createInjectable(
	() => {
		const myState = signal(1);
		return { myState: myState.asReadonly() };
	},
	{ providedIn: 'root' },
);
```

```ts
// using the service
const myService = inject(MyService);
```

@nartc I remember briefly discussing changing the `{ isRoot: false }` option in `createInjectionToken` - if that is still happening we could add a change to `createInjectable` to pre-empt whatever that is going to be?