### PR TITLE
refactor: createEffect() !

### DIFF
--- a/docs/src/content/docs/utilities/Stores/create-effect.md
+++ b/docs/src/content/docs/utilities/Stores/create-effect.md
@@ -3,7 +3,7 @@ title: createEffect
 description: ngxtension/create-effect
 entryPoint: create-effect
 badge: stable
-contributors: ['chau-tran']
+contributors: ['chau-tran', 'evgeniy-oz']
 ---
 
 `createEffect` is a standalone version of [NgRx ComponentStore Effect](https://ngrx.io/guide/component-store/effect)
@@ -63,11 +63,33 @@ export class Some {
 				tap(console.log.bind(console, 'multiply is -->')),
 			),
 			// 4. pass in the injector
-			this.injector,
+			{ injector: this.injector },
 		);
 
 		// 5. start the effect
 		log(interval(1000));
 	}
+}
+```
+
+### Resubscribe on errors
+
+By default, `createEffect()` will re-subscribe on errors, using `retry()` operator.  
+This behavior can be configured or turned off, using optional second argument:
+
+```ts
+@Component({})
+export class Example {
+	// Will not resubscribe on error
+	private loadProducts = createEffect<string>(
+		(_) => _.pipe(switchMap((id) => this.api.loadProducts(id))),
+		{ retryOnEror: false },
+	);
+
+	// Will resubscribe on error with a delay, not more than 3 times
+	private loadProducts = createEffect<string>(
+		(_) => _.pipe(switchMap((id) => this.api.loadProducts(id))),
+		{ retryOnEror: { count: 3, delay: 500 } },
+	);
 }
 ```

--- a/libs/ngxtension/create-effect/src/create-effect.spec.ts
+++ b/libs/ngxtension/create-effect/src/create-effect.spec.ts
@@ -1,9 +1,33 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { interval, tap } from 'rxjs';
+import { EMPTY, Subject, interval, of, switchMap, tap, throwError } from 'rxjs';
 import { createEffect } from './create-effect';
 
 describe(createEffect.name, () => {
+	let effect: ReturnType<typeof createEffect<string>>;
+	let lastResult: string | undefined;
+	let lastError: string | undefined;
+
+	beforeEach(() => {
+		lastResult = undefined;
+
+		TestBed.runInInjectionContext(() => {
+			effect = createEffect<string>((_) =>
+				_.pipe(
+					tap((r) => (lastResult = r)),
+					switchMap((v) => {
+						if (v === 'error') {
+							lastError = v;
+							return throwError(() => 'err');
+						}
+						lastError = undefined;
+						return of(v);
+					}),
+				),
+			);
+		});
+	});
+
 	@Component({
 		standalone: true,
 		template: '',
@@ -33,4 +57,98 @@ describe(createEffect.name, () => {
 		tick(1000);
 		expect(component.count).toEqual(2);
 	}));
+
+	it('should keep working when generator throws an error', () => {
+		expect(lastError).toEqual(undefined);
+		effect('error');
+		expect(lastResult).toEqual('error');
+		expect(lastError).toEqual('error');
+
+		effect('next');
+		expect(lastResult).toEqual('next');
+		expect(lastError).toEqual(undefined);
+	});
+
+	it('should keep working when value$ throws an error', () => {
+		expect(lastError).toEqual(undefined);
+		const s = new Subject<string>();
+		const m = s.pipe(
+			switchMap((v) => {
+				if (v === 'error') {
+					return throwError(() => 'err');
+				}
+				if (v === 'empty') {
+					return EMPTY;
+				}
+				return of(v);
+			}),
+		);
+		effect(m);
+		s.next('a');
+		expect(lastResult).toEqual('a');
+		s.next('error');
+		expect(lastResult).toEqual('a');
+		s.next('b');
+		expect(lastResult).toEqual('b');
+
+		effect('next');
+		expect(lastResult).toEqual('next');
+		expect(lastError).toEqual(undefined);
+	});
+
+	it('should keep working when value$ emits EMPTY', () => {
+		expect(lastError).toEqual(undefined);
+		const s = new Subject<string>();
+		const m = s.pipe(
+			switchMap((v) => {
+				if (v === 'error') {
+					return throwError(() => 'err');
+				}
+				if (v === 'empty') {
+					return EMPTY;
+				}
+				return of(v);
+			}),
+		);
+		effect(m);
+		s.next('a');
+		expect(lastResult).toEqual('a');
+		s.next('empty');
+		expect(lastResult).toEqual('a');
+		s.next('b');
+		expect(lastResult).toEqual('b');
+
+		effect('next');
+		expect(lastResult).toEqual('next');
+		expect(lastError).toEqual(undefined);
+	});
+
+	it('should accept signal as an argument', () => {
+		const s = signal<string>('a');
+		effect(s);
+		TestBed.flushEffects();
+		expect(lastResult).toEqual('a');
+		expect(lastError).toEqual(undefined);
+
+		s.set('b');
+		TestBed.flushEffects();
+		expect(lastResult).toEqual('b');
+		expect(lastError).toEqual(undefined);
+
+		s.set('error');
+		s.set('not an error');
+		TestBed.flushEffects();
+		expect(lastResult).toEqual('not an error');
+		expect(lastError).toEqual(undefined);
+
+		s.set('not an error');
+		s.set('error');
+		TestBed.flushEffects();
+		expect(lastError).toEqual('error');
+
+		s.set('c');
+		TestBed.flushEffects();
+		expect(lastResult).toEqual('c');
+		expect(lastError).toEqual(undefined);
+	});
 });


### PR DESCRIPTION
* Function, returned by `createEffect()` now accepts `Signal<T> | WritableSignal<T>` as an argument;
* `createEffect()` now has optional configuration argument of type `CreateEffectOptions`. Here you can pass an injector, configure if function should retry on error (true by default), and pass `retry()` configuration options. All fields are optional.
* Documentation of `createEffect()` is updated to reflect the changes.

BREAKING CHANGE: second argument, `injector`, is replaced by an object with fields `injector` and `retryOnError`.