### PR TITLE
fix(convert-signal-inputs): handle input name overlap in template

### DIFF
--- a/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
@@ -27,6 +27,12 @@ import { input } from "@angular/core";
     <app-test [acceptsString]="withoutDefaultAlias() || withDefaultAlias()" />
   </ng-container>
 </ng-container>
+
+<test [normalInput]="normalInput()" />
+<test-normalInput />
+<normalInput />
+<another-component something="blah-normalInput" />
+
   \`
 })
 export class MyCmp {
@@ -211,5 +217,11 @@ exports[`convertSignalInputsGenerator should convert properly for templateUrl 2`
   <ng-container *ngIf="withoutDefaultAlias()">
     <app-test [acceptsString]="withoutDefaultAlias() || withDefaultAlias()" />
   </ng-container>
-</ng-container>"
+</ng-container>
+
+<test [normalInput]="normalInput()" />
+<test-normalInput />
+<normalInput />
+<another-component something="blah-normalInput" />
+"
 `;

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
@@ -22,7 +22,13 @@ const template = `<div>{{ inputWithoutType }}</div>
   <ng-container *ngIf="withoutDefaultAlias">
     <app-test [acceptsString]="withoutDefaultAlias || withDefaultAlias" />
   </ng-container>
-</ng-container>`;
+</ng-container>
+
+<test [normalInput]="normalInput" />
+<test-normalInput />
+<normalInput />
+<another-component something="blah-normalInput" />
+`;
 
 const filesMap = {
 	notComponentNorDirective: `

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -339,7 +339,7 @@ export async function convertSignalInputsGenerator(
 								convertedInputs.forEach((convertedInput) => {
 									originalText = originalText.replaceAll(
 										new RegExp(
-											`\\b\(?!\\[\)${convertedInput}\\b\(?!\\]\)`,
+											`(?<!<)(?<!\\[)(?<![\\w-])\\b${convertedInput}\\b(?!\\])(?!>)(?![\\w-])`,
 											'gm',
 										),
 										`${convertedInput}()`,
@@ -365,7 +365,10 @@ export async function convertSignalInputsGenerator(
 								if (templateText) {
 									convertedInputs.forEach((convertedInput) => {
 										templateText = templateText.replaceAll(
-											new RegExp(`\\b${convertedInput}\\b`, 'gm'),
+											new RegExp(
+												`(?<!<)(?<!\\[)(?<![\\w-])\\b${convertedInput}\\b(?!\\])(?!>)(?![\\w-])`,
+												'gm',
+											),
 											`${convertedInput}()`,
 										);
 									});


### PR DESCRIPTION
I used the signal inputs generator on a big project recently and ran into trouble with cases like this:

```
<test [normalInput]="normalInput" />
<test-normalInput />
<normalInput />
<another-component something="blah-normalInput" />
```

In cases where:
* A child component input had the same name as a parent component input
* The name of an input was used as part of a tag name
* The name of an input was used within a property value

The template was being updated incorrectly, e.g:

```
<test [normalInput()]="normalInput()" />
<test-normalInput() />
<normalInput() />
<another-component something="blah-normalInput()" />
```

**NOTE:** I noticed there where two different regexes being used for the template based on whether it was a templateUrl or inline. One was simpler and I assume was mistaking left un-updated whilst the other one had been updated to something more complex. I have updated both to use the same updated regex now, but wanted to make a note in case something intentional was happening here

This updates the RegExp to handle the cases I mentioned, break down from ChatGPT who gets credit for writing the actual regex:

* (?<![\\w-]): Negative lookbehind to ensure ${convertedInput} is not immediately preceded by any word character or hyphen.
* \\b${convertedInput}\\b: Matches ${convertedInput} as a whole word.
* (?!\\]): Negative lookahead to ensure ${convertedInput} is not immediately followed by ].
* (?!>): Negative lookahead to ensure ${convertedInput} is not immediately followed by >.
* (?![\\w-]): Negative lookahead to ensure ${convertedInput} is not immediately followed by any word character or hyphen.