### PR TITLE
feat(connect): allow updating partial values with signal through ConnectedSignal

### DIFF
--- a/libs/ngxtension/connect/src/connect.spec.ts
+++ b/libs/ngxtension/connect/src/connect.spec.ts
@@ -55,7 +55,7 @@ describe(connect.name, () => {
 			});
 		});
 
-		it.only('should allow connecting with a signal', () => {
+		it('should allow connecting with a partial value from signal', () => {
 			const state = signal({
 				user: {
 					firstName: 'chau',
@@ -66,17 +66,43 @@ describe(connect.name, () => {
 			});
 
 			TestBed.runInInjectionContext(() => {
-				const testSignal = signal<any>({
+				const sourceSignalOne = signal({
 					user: { firstName: 'Chau', lastName: 'Tran' },
 				});
-				const connectedSignal = connect(state).with(() => testSignal());
+				const expectedOne = {
+					...state(),
+					user: { firstName: 'Chau', lastName: 'Tran' },
+				};
+				const connectedSignal = connect(state).with(() => sourceSignalOne());
 				TestBed.flushEffects();
-				expect(state().user).toEqual({ firstName: 'Chau', lastName: 'Tran' });
+				expect(state()).toEqual(expectedOne);
 
-				testSignal.set({ age: 32 });
-				connectedSignal.with(() => testSignal());
+				const sourceSignalTwo = signal({ age: 32 });
+				const expectedTwo = { ...expectedOne, age: 32 };
+				connectedSignal.with(() => sourceSignalTwo());
 				TestBed.flushEffects();
-				expect(state().age).toEqual(32);
+				expect(state()).toEqual(expectedTwo);
+
+				sourceSignalOne.set({
+					user: { firstName: 'Josh', lastName: 'Morony' },
+				});
+				const expectedThree = {
+					...expectedTwo,
+					user: { firstName: 'Josh', lastName: 'Morony' },
+				};
+				TestBed.flushEffects();
+				expect(state()).toEqual(expectedThree);
+			});
+		});
+
+		it('should allow connecting primitive value', () => {
+			const state = signal(4);
+
+			TestBed.runInInjectionContext(() => {
+				const sourceSignalOne = signal(5);
+				connect(state).with(() => sourceSignalOne());
+				TestBed.flushEffects();
+				expect(state()).toEqual(5);
 			});
 		});
 	});

--- a/libs/ngxtension/connect/src/connect.spec.ts
+++ b/libs/ngxtension/connect/src/connect.spec.ts
@@ -54,6 +54,31 @@ describe(connect.name, () => {
 				});
 			});
 		});
+
+		it.only('should allow connecting with a signal', () => {
+			const state = signal({
+				user: {
+					firstName: 'chau',
+					lastName: 'tran',
+				},
+				age: 30,
+				likes: ['angular', 'typescript'],
+			});
+
+			TestBed.runInInjectionContext(() => {
+				const testSignal = signal<any>({
+					user: { firstName: 'Chau', lastName: 'Tran' },
+				});
+				const connectedSignal = connect(state).with(() => testSignal());
+				TestBed.flushEffects();
+				expect(state().user).toEqual({ firstName: 'Chau', lastName: 'Tran' });
+
+				testSignal.set({ age: 32 });
+				connectedSignal.with(() => testSignal());
+				TestBed.flushEffects();
+				expect(state().age).toEqual(32);
+			});
+		});
 	});
 
 	describe('connects an observable to a signal in injection context', () => {

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -26,6 +26,9 @@ type ConnectedSignal<TSignalValue> = {
 		observable: Observable<TObservableValue>,
 		reducer: Reducer<TSignalValue, TObservableValue>,
 	): ConnectedSignal<TSignalValue>;
+	with<TSignalValue>(
+		originSignal: () => TSignalValue,
+	): ConnectedSignal<TSignalValue>;
 	subscription: Subscription;
 };
 
@@ -195,13 +198,23 @@ function parseArgs(
 
 	if (args.length === 3) {
 		if (typeof args[2] === 'boolean') {
-			return [
-				args[0] as Observable<unknown>,
-				null,
-				args[1] as Injector | DestroyRef,
-				args[2],
-				null,
-			];
+			if (isObservable(args[0])) {
+				return [
+					args[0] as Observable<unknown>,
+					null,
+					args[1] as Injector | DestroyRef,
+					args[2],
+					null,
+				];
+			} else {
+				return [
+					null,
+					null,
+					args[1] as Injector | DestroyRef,
+					args[2],
+					args[0] as () => unknown,
+				];
+			}
 		}
 
 		return [


### PR DESCRIPTION
This PR proposes two changes:
* Allow supplying a signal to `.with` as well as to `connect` directly
* Allow for partial state updates with an origin signal

The primary use case I am aiming to support here is this (essentially allowing signals driven changes as well as observables):

```ts
	// sources
	private dogs = computedAsync(() => {
		this.someService.version(); // retrigger when version changes
		return this.dbService.getDogs();
	});

	private cats = computedAsync(() => {
		this.someService.version();
		return this.dbService.getCats();
	});

	// centralised state
	private state = signal({
		dogs: undefined,
		cats: undefined,
        })

	constructor() {
		// reducers
		connect(this.state)
                   .with(() => ({ dogs: this.dogs() }))
                   .with(() => ({ cats: this.cats() }));
	}
```

The current behaviour with origin signals does not allow partial updates, this PR changes that, but I may be missing some reason why this was the case in the first place.

If it isn't desirable to include the partial updates change as well, I can update this PR to just include the change which allows this:

```ts
connect(this.state).with(() => ({ dogs: this.dogs() }));
```

as well as this (bottom is currently supported, top isn't):

```ts
connect(this.state, () => ({ dogs: this.dogs() }));
```