### PR TITLE
feat(create-notifier): add createNotifier

### DIFF
--- a/docs/src/content/docs/utilities/Signals/create-notifier.md
+++ b/docs/src/content/docs/utilities/Signals/create-notifier.md
@@ -1,0 +1,64 @@
+---
+title: createNotifier
+description: ngxtension/create-notifier
+entryPoint: create-notifier
+badge: experimental
+contributors: ['josh-morony']
+---
+
+`createNotifier` provides a way to manually trigger signal re-computations by
+referencing the created notifier signal. Common use cases for this include:
+
+- Manually triggering a "refresh" and reacting to it
+- Mutating a `Map` and having a way to react to that map changing
+- Triggering a re-computation on some kind of event/life cycle hook
+
+It simply creates a standard `signal` that has its value incremented by `1`
+every time `notify` is called. This means the signal value will change and any
+`effect` or `computed` that references this signal will be re-computed.
+
+You can create a notifier like this:
+
+```ts
+import { createNotifier } from 'ngxtension/create-notifier';
+```
+
+```ts
+refreshNotifier = createNotifier();
+```
+
+You can trigger the signal update like this:
+
+```ts
+refreshNotifier.notify();
+```
+
+Then you can trigger a re-computation of any `computed` or `effect` (or
+`computedAsync` from `ngxtension`) by referencing the signal returned on
+`listen`:
+
+```ts
+effect(() => {
+	refreshNotifier.listen();
+
+	// whatever code you want to run whenever
+	// refreshNotifier.notify() is called
+});
+```
+
+An important thing to keep in mind is that an `effect` will also run once
+initially before `notify()` is explicitly called. Since the version number used
+internally for the signals value begins with `0` you can avoid this "init"
+behaviour by setting up your effect like this instead:
+
+```ts
+effect(() => {
+	if (refreshNotifier.listen()) {
+		// Will NOT run on init
+		// whatever code you want to run whenever
+		// refreshNotifier.notify() is called
+	}
+});
+```
+
+With this set up, the `if` will initially fail because the value of `refreshNotifier.listen()` will initially be `0`, but once `notify` has been explicitly called the `if` condition will always pass because the value of the signal will always be above `0`.

--- a/libs/ngxtension/create-notifier/README.md
+++ b/libs/ngxtension/create-notifier/README.md
@@ -1,0 +1,3 @@
+# ngxtension/create-notifier
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/create-notifier`.

--- a/libs/ngxtension/create-notifier/ng-package.json
+++ b/libs/ngxtension/create-notifier/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/create-notifier/project.json
+++ b/libs/ngxtension/create-notifier/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/create-notifier",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/create-notifier/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["create-notifier"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/create-notifier/src/create-notifier.spec.ts
+++ b/libs/ngxtension/create-notifier/src/create-notifier.spec.ts
@@ -1,0 +1,41 @@
+import { effect } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { createNotifier } from './create-notifier';
+
+describe(createNotifier.name, () => {
+	it('should trigger on init', () => {
+		TestBed.runInInjectionContext(() => {
+			const testFn = jest.fn();
+			const trigger = createNotifier();
+
+			effect(() => {
+				trigger.listen();
+				testFn();
+			});
+
+			TestBed.flushEffects();
+			expect(testFn).toHaveBeenCalled();
+		});
+	});
+
+	it('should allow not triggering until explicitly called', () => {
+		TestBed.runInInjectionContext(() => {
+			const testFn = jest.fn();
+			const trigger = createNotifier();
+
+			effect(() => {
+				if (trigger.listen()) {
+					testFn();
+				}
+			});
+
+			TestBed.flushEffects();
+			expect(testFn).not.toHaveBeenCalled();
+
+			trigger.notify();
+
+			TestBed.flushEffects();
+			expect(testFn).toHaveBeenCalled();
+		});
+	});
+});

--- a/libs/ngxtension/create-notifier/src/create-notifier.spec.ts
+++ b/libs/ngxtension/create-notifier/src/create-notifier.spec.ts
@@ -38,4 +38,29 @@ describe(createNotifier.name, () => {
 			expect(testFn).toHaveBeenCalled();
 		});
 	});
+
+	it('should continue to trigger when additional calls are made', () => {
+		TestBed.runInInjectionContext(() => {
+			const testFn = jest.fn();
+			const trigger = createNotifier();
+
+			effect(() => {
+				if (trigger.listen()) {
+					testFn();
+				}
+			});
+
+			TestBed.flushEffects();
+			expect(testFn).not.toHaveBeenCalled();
+
+			trigger.notify();
+
+			TestBed.flushEffects();
+			expect(testFn).toHaveBeenCalledTimes(1);
+
+			trigger.notify();
+			TestBed.flushEffects();
+			expect(testFn).toHaveBeenCalledTimes(2);
+		});
+	});
 });

--- a/libs/ngxtension/create-notifier/src/create-notifier.ts
+++ b/libs/ngxtension/create-notifier/src/create-notifier.ts
@@ -1,0 +1,12 @@
+import { signal } from '@angular/core';
+
+export function createNotifier() {
+	const sourceSignal = signal(0);
+
+	return {
+		notify: () => {
+			sourceSignal.update((v) => v + 1);
+		},
+		listen: sourceSignal.asReadonly(),
+	};
+}

--- a/libs/ngxtension/create-notifier/src/index.ts
+++ b/libs/ngxtension/create-notifier/src/index.ts
@@ -1,0 +1,1 @@
+export const greeting = 'Hello World!';

--- a/libs/ngxtension/create-notifier/src/index.ts
+++ b/libs/ngxtension/create-notifier/src/index.ts
@@ -1,1 +1,1 @@
-export const greeting = 'Hello World!';
+export * from './create-notifier';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -55,6 +55,9 @@
 			"ngxtension/create-injection-token": [
 				"libs/ngxtension/create-injection-token/src/index.ts"
 			],
+			"ngxtension/create-notifier": [
+				"libs/ngxtension/create-notifier/src/index.ts"
+			],
 			"ngxtension/create-signal": [
 				"libs/ngxtension/create-signal/src/index.ts"
 			],


### PR DESCRIPTION
This is an initial implementation for the `createNotifier` feature discussed here: https://github.com/nartc/ngxtension-platform/issues/276

This incorporates some of the feedback in the discussion and we can continue to iterate on the exact API (personally I am happy with it as is but happy to change as well)

Once the exact implementation is settled I will add some docs to this PR (along with some more tests too)