### PR TITLE
fix(convert-signal-inputs): don't convert when input name used as property

### DIFF
--- a/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
@@ -33,6 +33,8 @@ import { input } from "@angular/core";
 <normalInput />
 <another-component something="blah-normalInput" />
 
+<p>{{ data().normalInput }}</p>
+
   \`
 })
 export class MyCmp {
@@ -223,5 +225,7 @@ exports[`convertSignalInputsGenerator should convert properly for templateUrl 2`
 <test-normalInput />
 <normalInput />
 <another-component something="blah-normalInput" />
+
+<p>{{ data().normalInput }}</p>
 "
 `;

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
@@ -28,6 +28,8 @@ const template = `<div>{{ inputWithoutType }}</div>
 <test-normalInput />
 <normalInput />
 <another-component something="blah-normalInput" />
+
+<p>{{ data().normalInput }}</p>
 `;
 
 const filesMap = {

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -339,7 +339,7 @@ export async function convertSignalInputsGenerator(
 								convertedInputs.forEach((convertedInput) => {
 									originalText = originalText.replaceAll(
 										new RegExp(
-											`(?<!<)(?<!\\[)(?<![\\w-])\\b${convertedInput}\\b(?!\\])(?!>)(?![\\w-])`,
+											`(?<!<)(?<!\\[)(?<![\\w-])(?<!\\.\\w*)\\b${convertedInput}\\b(?!\\])(?!>)(?![\\w-])`,
 											'gm',
 										),
 										`${convertedInput}()`,
@@ -366,7 +366,7 @@ export async function convertSignalInputsGenerator(
 									convertedInputs.forEach((convertedInput) => {
 										templateText = templateText.replaceAll(
 											new RegExp(
-												`(?<!<)(?<!\\[)(?<![\\w-])\\b${convertedInput}\\b(?!\\])(?!>)(?![\\w-])`,
+												`(?<!<)(?<!\\[)(?<![\\w-])(?<!\\.\\w*)\\b${convertedInput}\\b(?!\\])(?!>)(?![\\w-])`,
 												'gm',
 											),
 											`${convertedInput}()`,


### PR DESCRIPTION
Modifies regex so that if a property is accessed in the template that has the same name as some other input it won't be converted

closes #278 