### PR TITLE
refactor: use Proxy in toObservableSignal() instead of methods linking, to be compatible with RxJS v8

### DIFF
--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
@@ -9,7 +9,6 @@ describe('toObservableSignal()', () => {
 		const injector = TestBed.inject(Injector);
 		const observableSignal = toObservableSignal(s, { injector });
 
-		expect(observableSignal).toEqual(s);
 		expect(observableSignal.subscribe).toBeDefined();
 		expect(observableSignal.pipe).toBeDefined();
 		expect(observableSignal.set).toBeDefined();
@@ -25,7 +24,6 @@ describe('toObservableSignal()', () => {
 		const injector = TestBed.inject(Injector);
 		const observableSignal = toObservableSignal(s, { injector });
 
-		expect(observableSignal).toEqual(s);
 		expect(observableSignal.subscribe).toBeDefined();
 		expect(observableSignal.pipe).toBeDefined();
 		expect((observableSignal as any)['set']).toBeUndefined();

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
@@ -30,8 +30,13 @@ export function toObservableSignal<T>(
 	}
 
 	const obs = toObservable(s, options);
-	for (const obsKey in obs) {
-		(s as any)[obsKey] = (obs as any)[obsKey];
-	}
-	return s;
+
+	return new Proxy(s, {
+		get(_, prop) {
+			if ((s as any)[prop]) {
+				return (s as any)[prop];
+			}
+			return (obs as any)[prop];
+		},
+	});
 }

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
@@ -33,7 +33,7 @@ export function toObservableSignal<T>(
 
 	return new Proxy(s, {
 		get(_, prop) {
-			if ((s as any)[prop]) {
+			if (prop in s) {
 				return (s as any)[prop];
 			}
 			return (obs as any)[prop];


### PR DESCRIPTION
This change removes a bit dirty method of combining the functionality of Angular Signal and RxJS Observable.
Previously, every field of Observable instance was copied to a Signal object.
Now we return a Proxy object, that only returns a method of the Observable instance if the Signal instance does not have the requested method.