### PR TITLE
fix(convert-signal-inputs): handle automatic semicolon insertion issues

### DIFF
--- a/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
@@ -229,3 +229,17 @@ exports[`convertSignalInputsGenerator should convert properly for templateUrl 2`
 <p>{{ data().normalInput }}</p>
 "
 `;
+
+exports[`convertSignalInputsGenerator should fail gracefully for issue #290 1`] = `
+"
+import { Component } from '@angular/core';
+import { input } from "@angular/core";
+
+@Component({})
+export class MyCmp {
+  inputWithoutType = input();
+  noColon = true
+    inputWithoutType = input();;
+}
+"
+`;

--- a/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
@@ -229,17 +229,3 @@ exports[`convertSignalInputsGenerator should convert properly for templateUrl 2`
 <p>{{ data().normalInput }}</p>
 "
 `;
-
-exports[`convertSignalInputsGenerator should fail gracefully for issue #290 1`] = `
-"
-import { Component } from '@angular/core';
-import { input } from "@angular/core";
-
-@Component({})
-export class MyCmp {
-  inputWithoutType = input();
-  noColon = true
-    inputWithoutType = input();;
-}
-"
-`;

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
@@ -255,10 +255,11 @@ describe('convertSignalInputsGenerator', () => {
 		expect(updated).toMatchSnapshot();
 	});
 
-	it('should fail gracefully for issue #290', async () => {
+	it('should fail for issue #290', async () => {
 		const readContent = setup('issue290');
-		await convertSignalInputsGenerator(tree, options);
-		const [updated] = readContent();
-		expect(updated).toMatchSnapshot();
+		await expect(async () => {
+			await convertSignalInputsGenerator(tree, options);
+			readContent();
+		}).rejects.toThrow();
 	});
 });

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
@@ -180,6 +180,15 @@ export class RequestInfoComponent implements OnInit {
     this.submitter$.next();
   }
 }`,
+	issue290: `
+import { Component } from '@angular/core';
+
+@Component({})
+export class MyCmp {
+  @Input() inputWithoutType;
+  noColon = true
+}
+`,
 } as const;
 
 describe('convertSignalInputsGenerator', () => {
@@ -241,6 +250,13 @@ describe('convertSignalInputsGenerator', () => {
 
 	it('should convert properly for issue #236', async () => {
 		const readContent = setup('issue236');
+		await convertSignalInputsGenerator(tree, options);
+		const [updated] = readContent();
+		expect(updated).toMatchSnapshot();
+	});
+
+	it('should fail gracefully for issue #290', async () => {
+		const readContent = setup('issue290');
 		await convertSignalInputsGenerator(tree, options);
 		const [updated] = readContent();
 		expect(updated).toMatchSnapshot();

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -286,32 +286,39 @@ export async function convertSignalInputsGenerator(
 
 			targetClass.forEachChild((node) => {
 				if (Node.isPropertyDeclaration(node)) {
-					const inputDecorator = node.getDecorator('Input');
-					if (inputDecorator) {
-						const { name, isReadonly, docs, scope, hasOverrideKeyword } =
-							node.getStructure();
+					// fail gracefully for nodes not terminated with a semi-colon
+					try {
+						const inputDecorator = node.getDecorator('Input');
+						if (inputDecorator) {
+							const { name, isReadonly, docs, scope, hasOverrideKeyword } =
+								node.getStructure();
 
-						const newProperty = targetClass.addProperty({
-							name,
-							isReadonly,
-							docs,
-							scope,
-							hasOverrideKeyword,
-							initializer: getSignalInputInitializer(
-								contentsStore,
-								targetClass.getName(),
-								inputDecorator,
-								node,
-							),
-						});
+							const newProperty = targetClass.addProperty({
+								name,
+								isReadonly,
+								docs,
+								scope,
+								hasOverrideKeyword,
+								initializer: getSignalInputInitializer(
+									contentsStore,
+									targetClass.getName(),
+									inputDecorator,
+									node,
+								),
+							});
 
-						node.replaceWithText(newProperty.print());
+							node.replaceWithText(newProperty.print());
 
-						// remove old class property Input
-						newProperty.remove();
+							// remove old class property Input
+							newProperty.remove();
 
-						// track converted inputs
-						convertedInputs.add(name);
+							// track converted inputs
+							convertedInputs.add(name);
+						}
+					} catch (err) {
+						logger.warn(
+							`[ngxtension] "${path}" Failed to parse node, consider formatting with prettier and trying again`,
+						);
 					}
 				}
 			});

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -286,39 +286,40 @@ export async function convertSignalInputsGenerator(
 
 			targetClass.forEachChild((node) => {
 				if (Node.isPropertyDeclaration(node)) {
-					// fail gracefully for nodes not terminated with a semi-colon
-					try {
-						const inputDecorator = node.getDecorator('Input');
-						if (inputDecorator) {
-							const { name, isReadonly, docs, scope, hasOverrideKeyword } =
-								node.getStructure();
+					const inputDecorator = node.getDecorator('Input');
+					if (inputDecorator) {
+						const { name, isReadonly, docs, scope, hasOverrideKeyword } =
+							node.getStructure();
 
-							const newProperty = targetClass.addProperty({
-								name,
-								isReadonly,
-								docs,
-								scope,
-								hasOverrideKeyword,
-								initializer: getSignalInputInitializer(
-									contentsStore,
-									targetClass.getName(),
-									inputDecorator,
-									node,
-								),
-							});
+						const newProperty = targetClass.addProperty({
+							name,
+							isReadonly,
+							docs,
+							scope,
+							hasOverrideKeyword,
+							initializer: getSignalInputInitializer(
+								contentsStore,
+								targetClass.getName(),
+								inputDecorator,
+								node,
+							),
+						});
 
-							node.replaceWithText(newProperty.print());
+						node.replaceWithText(newProperty.print());
 
+						// fail gracefully for nodes not terminated with a semi-colon
+						try {
 							// remove old class property Input
 							newProperty.remove();
-
-							// track converted inputs
-							convertedInputs.add(name);
+						} catch (err) {
+							logger.warn(
+								`[ngxtension] "${path}" Failed to parse node, check that declarations are terminated with a semicolon and try again`,
+							);
+							throw err;
 						}
-					} catch (err) {
-						logger.warn(
-							`[ngxtension] "${path}" Failed to parse node, consider formatting with prettier and trying again`,
-						);
+
+						// track converted inputs
+						convertedInputs.add(name);
 					}
 				}
 			});


### PR DESCRIPTION
fixes #290 

Due to Automatic Semicolon Insertion this is valid JS/TS syntax:

```ts
@Component({})
export class MyCmp {
  @Input() inputWithoutType;
  noColon = true
}
```

But when processing property declarations this can mess with ts-morph since ASI has not been applied. This PR catches errors arising from this situation and warns to attempt fixing it and trying again.