### PR TITLE
feat(useLocalStorage): Initial implementation of useLocalStorage 

### DIFF
--- a/libs/ngxtension/use-local-storage/README.md
+++ b/libs/ngxtension/use-local-storage/README.md
@@ -1,0 +1,3 @@
+# ngxtension/use-local-storage
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/use-local-storage`.

--- a/libs/ngxtension/use-local-storage/ng-package.json
+++ b/libs/ngxtension/use-local-storage/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/use-local-storage/project.json
+++ b/libs/ngxtension/use-local-storage/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/use-local-storage",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/use-local-storage/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["use-local-storage"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/use-local-storage/src/index.ts
+++ b/libs/ngxtension/use-local-storage/src/index.ts
@@ -1,0 +1,1 @@
+export * from './use-local-storage';

--- a/libs/ngxtension/use-local-storage/src/use-local-storage.spec.ts
+++ b/libs/ngxtension/use-local-storage/src/use-local-storage.spec.ts
@@ -1,0 +1,157 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { useLocalStorage } from './use-local-storage';
+
+describe('useLocalStorage', () => {
+	const key = 'testKey';
+	let setItemSpy: jest.SpyInstance;
+	let getItemSpy: jest.SpyInstance;
+	let storageEventSubject: Subject<Event>;
+
+	beforeEach(() => {
+		storageEventSubject = new Subject<Event>();
+		setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+		getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(null); // Default mock to return null
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('with primitive', () => {
+		it('should set a value in localStorage', () => {
+			TestBed.runInInjectionContext(() => {
+				let { set } = useLocalStorage<string>(key);
+				const testValue = 'value';
+				set(testValue);
+				expect(setItemSpy).toHaveBeenCalledWith(key, JSON.stringify(testValue));
+			});
+		});
+
+		it('should get the current value from localStorage', () => {
+			TestBed.runInInjectionContext(() => {
+				const testValue = 'value';
+				getItemSpy.mockReturnValue(JSON.stringify(testValue)); // Mock return value for getItem
+
+				const { value } = useLocalStorage<string>(key);
+
+				expect(value()).toEqual(testValue);
+			});
+		});
+
+		it('should handle validation correctly', () => {
+			TestBed.runInInjectionContext(() => {
+				const invalidValue = 'invalid';
+				const validate = (value: unknown) => value === 'valid';
+				getItemSpy.mockReturnValue(JSON.stringify(invalidValue)); // Mock return value for getItem
+
+				const { value } = useLocalStorage<string>(key, validate);
+
+				expect(value()).toBeNull;
+			});
+		});
+
+		it('should emit an error if JSON parsing fails', () => {
+			TestBed.runInInjectionContext(() => {
+				getItemSpy.mockReturnValue('not a valid json'); // Mock return value for getItem
+
+				const { error } = useLocalStorage<string>(key);
+				expect(error()).toBeInstanceOf(Error);
+			});
+		});
+
+		it('should react to external localStorage changes', () => {
+			TestBed.runInInjectionContext(() => {
+				const newValue = 'new value';
+				getItemSpy.mockReturnValue(JSON.stringify(newValue)); // Mock return value for getItem after change
+
+				const { value } = useLocalStorage<string>(key);
+
+				// Simulate an external change
+				storageEventSubject.next(new Event('storage'));
+
+				expect(value()).toEqual(newValue);
+			});
+		});
+	});
+
+	describe('with object', () => {
+		it('should set a value in localStorage', () => {
+			TestBed.runInInjectionContext(() => {
+				const testValue = { house: { rooms: 3, bathrooms: 2 } };
+				let { set } = useLocalStorage<typeof testValue>(key);
+				set(testValue);
+				expect(setItemSpy).toHaveBeenCalledWith(key, JSON.stringify(testValue));
+			});
+		});
+
+		it('should get the current value from localStorage', () => {
+			TestBed.runInInjectionContext(() => {
+				const testValue = { house: { rooms: 3, bathrooms: 2 } };
+				getItemSpy.mockReturnValue(JSON.stringify(testValue)); // Mock return value for getItem
+
+				const { value } = useLocalStorage<typeof testValue>(key);
+
+				expect(value()).toEqual(testValue);
+			});
+		});
+
+		it('should handle validation correctly', () => {
+			TestBed.runInInjectionContext(() => {
+				const invalidValue = { house: { rooms: 3, bathrooms: 2 } };
+				const validate = (value: unknown) => value === 'valid';
+				getItemSpy.mockReturnValue(JSON.stringify(invalidValue)); // Mock return value for getItem
+
+				const { value } = useLocalStorage<typeof invalidValue>(key, validate);
+
+				expect(value()).toBeNull;
+			});
+		});
+
+		it('should emit an error if JSON parsing fails', () => {
+			TestBed.runInInjectionContext(() => {
+				getItemSpy.mockReturnValue('not a valid json'); // Mock return value for getItem
+
+				const { error } = useLocalStorage<string>(key);
+				expect(error()).toBeInstanceOf(Error);
+			});
+		});
+
+		it('should react to external localStorage changes', () => {
+			TestBed.runInInjectionContext(() => {
+				const newValue = { house: { rooms: 3, bathrooms: 2 } };
+				getItemSpy.mockReturnValue(JSON.stringify(newValue)); // Mock return value for getItem after change
+
+				const { value } = useLocalStorage<typeof newValue>(key);
+
+				// Simulate an external change
+				storageEventSubject.next(new Event('storage'));
+
+				expect(value()).toEqual(newValue);
+			});
+		});
+
+		it('should react to multiple localStorage changes', () => {
+			TestBed.runInInjectionContext(() => {
+				const val1 = { house: { rooms: 3, bathrooms: 2 } };
+				getItemSpy.mockReturnValue(JSON.stringify(val1));
+
+				const { set, value } = useLocalStorage<typeof val1>(key);
+
+				// Simulate an external change
+				storageEventSubject.next(new Event('storage'));
+				expect(value()).toEqual(val1);
+
+				const val2 = { house: { rooms: 3, bathrooms: 2 } };
+				getItemSpy.mockReturnValue(JSON.stringify(val2)); // Mock return value for getItem
+				storageEventSubject.next(new Event('storage'));
+				expect(value()).toEqual(val2);
+
+				const val3 = { house: { rooms: 3, bathrooms: 2 } };
+				getItemSpy.mockReturnValue(JSON.stringify(val3)); // Mock return value for getItem
+				set(val3);
+				expect(value()).toEqual(val2);
+			});
+		});
+	});
+});

--- a/libs/ngxtension/use-local-storage/src/use-local-storage.ts
+++ b/libs/ngxtension/use-local-storage/src/use-local-storage.ts
@@ -1,0 +1,61 @@
+import { computed, type Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import {
+	catchError,
+	distinctUntilChanged,
+	fromEvent,
+	merge,
+	Observable,
+	of,
+	startWith,
+	Subject,
+} from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export const useLocalStorage = <T>(
+	key: string,
+	validate?: (value: unknown) => boolean,
+): {
+	set: (value: T) => void;
+	value: Signal<T | null | undefined>;
+	error: Signal<Error | undefined>;
+} => {
+	const refresh$ = new Subject<void>();
+
+	const externalLocalStorageChanges$: Observable<
+		| { value: T | null }
+		| {
+				error: Error;
+		  }
+	> = merge(refresh$, fromEvent(window, 'storage')).pipe(
+		startWith(null), // Trigger initialization
+		map(() => localStorage.getItem(key)),
+		distinctUntilChanged(), // The fromEvent(window, 'storage') will emit whenever any tab changes the local storage, so we try to filter out the events that are not relevant to this key
+		map((stringValue) => {
+			const value =
+				stringValue === null ? null : (JSON.parse(stringValue) as T);
+			if (validate && !validate(value)) {
+				return { error: new Error('Invalid value') };
+			}
+			return { value };
+		}),
+		catchError((error) => of({ error })),
+	);
+
+	const initialState = toSignal(externalLocalStorageChanges$, {
+		requireSync: true,
+	});
+	const value = computed(() => (initialState() as { value: T }).value);
+	const error = computed(() => (initialState() as { error: Error }).error);
+
+	const setLocalStorage = (value: T) => {
+		window.localStorage.setItem(key, JSON.stringify(value));
+		refresh$.next();
+	};
+
+	return {
+		set: setLocalStorage,
+		value: value,
+		error: error,
+	};
+};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -115,6 +115,12 @@
 			"ngxtension/trackby-id-prop": [
 				"libs/ngxtension/trackby-id-prop/src/index.ts"
 			],
+			"ngxtension/use-local-storage": [
+				"libs/ngxtension/use-local-storage/src/index.ts"
+			],
+			"ngxtension/use-session-storage": [
+				"libs/ngxtension/use-session-storage/src/index.ts"
+			],
 			"plugin": ["libs/plugin/src/index.ts"]
 		}
 	},


### PR DESCRIPTION
This addresses https://github.com/nartc/ngxtension-platform/issues/245

Adds a utility that synchronizes localStorage changes across tabs, and has an optional validate method to verify the validity of the object.

I can create a PR for a similar/same thing for sessionStorage if this seems like a good idea/implementation.
Would love some feedback before I do that though :) 


