### PR TITLE
feat(convert-outputs): add migrations for new output() function

### DIFF
--- a/docs/src/content/docs/utilities/Migrations/new-outputs-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/new-outputs-migration.md
@@ -1,0 +1,48 @@
+---
+title: New output() Migration
+description: Schematics for migrating decorator outputs to function based outputs
+entryPoint: convert-outputs
+badge: stable
+contributors: ['enea-jahollari']
+---
+
+In Angular v17.3, new output() were released. The new output() function aligns better with the new input() and pave the road for signal components. This is the reason why `ngxtension` publishes schematics that handles the code migration for you.
+
+### How it works?
+
+The moment you run the schematics, it will look for all the decorators that have outputs and convert them to function based outputs.
+
+- It will keep the same name for the outputs.
+- It will keep the same types.
+- It will keep the same alias if it's present.
+- It will also convert Outputs that are used with observables and not with EventEmitter.
+
+### Usage
+
+In order to run the schematics for all the project in the app you have to run the following script:
+
+```bash
+ng g ngxtension:convert-outputs
+```
+
+If you want to specify the project name you can pass the `--project` param.
+
+```bash
+ng g ngxtension:convert-outputs --project=<project-name>
+```
+
+If you want to run the schematic for a specific component or directive you can pass the `--path` param.
+
+```bash
+ng g ngxtension:convert-outputs --path=<path-to-ts-file>
+```
+
+### Usage with Nx
+
+To use the schematics on a Nx monorepo you just swap `ng` with `nx`
+
+Example:
+
+```bash
+nx g ngxtension:convert-outputs --project=<project-name>
+```

--- a/docs/src/content/docs/utilities/Migrations/new-outputs-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/new-outputs-migration.md
@@ -6,7 +6,7 @@ badge: stable
 contributors: ['enea-jahollari']
 ---
 
-In Angular v17.3, new output() were released. The new output() function aligns better with the new input() and pave the road for signal components. This is the reason why `ngxtension` publishes schematics that handles the code migration for you.
+In Angular v17.3, the new `output()` was released. The new `output()` function aligns better with the new `input()` and pave the road for signal components. This is the reason why `ngxtension` publishes schematics that handles the code migration for you.
 
 ### How it works?
 
@@ -16,6 +16,66 @@ The moment you run the schematics, it will look for all the decorators that have
 - It will keep the same types.
 - It will keep the same alias if it's present.
 - It will also convert Outputs that are used with observables and not with EventEmitter.
+
+### Example:
+
+#### Normal output:
+
+Before:
+
+```ts
+@Output() change = new EventEmitter<string>();
+```
+
+After:
+
+```ts
+change = output<string>();
+```
+
+#### Output with alias:
+
+Before:
+
+```ts
+@Output('change') changeAlias = new EventEmitter<string>();
+```
+
+After:
+
+```ts
+change = output<string>({ alias: 'change' });
+```
+
+#### Output with observable:
+
+Before:
+
+```ts
+someObservable$ = of('test');
+@Output() change = this.someObservable$;
+```
+
+After:
+
+```ts
+change = outputFromObservable(this.someObservable$);
+```
+
+#### Output with Subject or BehaviorSubject:
+
+Before:
+
+```ts
+@Output() someSubject = new Subject<string>();
+```
+
+After:
+
+```ts
+someSubject = new Subject<string>();
+_someSubject = outputFromObservable(this.someSubject, { alias: 'someSubject' });
+```
 
 ### Usage
 

--- a/libs/plugin/generators.json
+++ b/libs/plugin/generators.json
@@ -10,6 +10,12 @@
 			"aliases": ["signal-inputs"],
 			"schema": "./src/generators/convert-signal-inputs/schema.json",
 			"description": "libs/plugin/src/generators/convert-signal-inputs/ generator"
+		},
+		"convert-outputs": {
+			"factory": "./src/generators/convert-outputs/generator",
+			"aliases": ["signal-outputs"],
+			"schema": "./src/generators/convert-outputs/schema.json",
+			"description": "libs/plugin/src/generators/convert-outputs/ generator"
 		}
 	},
 	"schematics": {
@@ -23,6 +29,12 @@
 			"aliases": ["signal-inputs"],
 			"schema": "./src/generators/convert-signal-inputs/schema.json",
 			"description": "libs/plugin/src/generators/convert-signal-inputs/ generator"
+		},
+		"convert-outputs": {
+			"factory": "./src/generators/convert-outputs/generator",
+			"aliases": ["signal-outputs"],
+			"schema": "./src/generators/convert-outputs/schema.json",
+			"description": "libs/plugin/src/generators/convert-outputs/ generator"
 		}
 	}
 }

--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -14,6 +14,10 @@ export class MyCmp {
 
   outputWithoutType = output();
   normalOutput = output<string>();
+
+  outputFromSubject = new Subject();
+  outputFromBehaviorSubject = new BehaviorSubject<number>();
+
   withObservable = outputFromObservable(this.someObservable$);
   aliasOutput = output<string>({ alias: 'withAlias' });
 
@@ -32,6 +36,12 @@ export class MyCmp {
     }
   }
 
+    /** TODO(migration): you may want to convert this to a normal output */
+    _outputFromSubject = outputFromObservable(this.outputFromSubject, { alias: 'outputFromSubject' });
+    /** TODO(migration): you may want to convert this to a normal output */
+    _outputFromBehaviorSubject = outputFromObservable(this.outputFromBehaviorSubject, { alias: 'outputFromBehaviorSubject' });
+;
+;
 ;
 ;
 ;

--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convertOutputsGenerator should convert properly 1`] = `
+"
+import { Component, Output, EventEmitter } from '@angular/core';
+import { output } from "@angular/core";
+import { outputFromObservable } from "@angular/core/rxjs-interop";
+
+@Component({
+  template: \` \`
+})
+export class MyCmp {
+  someObservable$ = of('test');
+
+  outputWithoutType = output();
+  normalOutput = output<string>();
+  withObservable = outputFromObservable(this.someObservable$);
+  aliasOutput = output<string>({ alias: 'withAlias' });
+
+  ngOnInit() {
+    let imABoolean = false;
+    console.log(this.outputWithoutType);
+
+    if (this.withTransform) {
+      this.normalOutput.emit('test');
+    }
+  }
+
+  handleClick() {
+    if (true) {
+      let test = this.outputWithoutType + this.normalOutput;
+    }
+  }
+
+;
+;
+;
+;
+}
+"
+`;
+
+exports[`convertOutputsGenerator should not add outputFromObservable import if not needed 1`] = `
+"
+import { Component, Output, EventEmitter } from '@angular/core';
+import { output } from "@angular/core";
+
+@Component({
+  template: \` \`
+})
+export class MyCmp {
+  outputWithoutType = output();
+  normalOutput = output<string>();
+;
+;
+}
+"
+`;

--- a/libs/plugin/src/generators/convert-outputs/compat.ts
+++ b/libs/plugin/src/generators/convert-outputs/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nx/devkit';
+import convertSignalInputsGenerator from './generator';
+
+export default convertNxGenerator(convertSignalInputsGenerator);

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -39,6 +39,10 @@ export class MyCmp {
 
   @Output() outputWithoutType = new EventEmitter();
   @Output() normalOutput = new EventEmitter<string>();
+
+  @Output() outputFromSubject = new Subject();
+  @Output() outputFromBehaviorSubject = new BehaviorSubject<number>();
+
   @Output() withObservable = this.someObservable$;
   @Output('withAlias') aliasOutput = new EventEmitter<string>();
 
@@ -60,7 +64,7 @@ export class MyCmp {
 `,
 } as const;
 
-describe('convertOutputsGenerator', () => {
+fdescribe('convertOutputsGenerator', () => {
 	let tree: Tree;
 	const options: ConvertOutputsGeneratorSchema = {
 		path: 'libs/my-file.ts',

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -1,0 +1,106 @@
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+
+import convertOutputsGenerator from './generator';
+import { ConvertOutputsGeneratorSchema } from './schema';
+
+const filesMap = {
+	notComponentNorDirective: `
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class MyService {}
+`,
+	componentNoOutput: `
+import { Component } from '@angular/core';
+
+@Component({})
+export class MyCmp {}
+`,
+	outputWithoutObservable: `
+import { Component, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  template: \` \`
+})
+export class MyCmp {
+  @Output() outputWithoutType = new EventEmitter();
+  @Output() normalOutput = new EventEmitter<string>();
+}
+`,
+	component: `
+import { Component, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  template: \` \`
+})
+export class MyCmp {
+  someObservable$ = of('test');
+
+  @Output() outputWithoutType = new EventEmitter();
+  @Output() normalOutput = new EventEmitter<string>();
+  @Output() withObservable = this.someObservable$;
+  @Output('withAlias') aliasOutput = new EventEmitter<string>();
+
+  ngOnInit() {
+    let imABoolean = false;
+    console.log(this.outputWithoutType);
+
+    if (this.withTransform) {
+      this.normalOutput.emit('test');
+    }
+  }
+
+  handleClick() {
+    if (true) {
+      let test = this.outputWithoutType + this.normalOutput;
+    }
+  }
+}
+`,
+} as const;
+
+describe('convertOutputsGenerator', () => {
+	let tree: Tree;
+	const options: ConvertOutputsGeneratorSchema = {
+		path: 'libs/my-file.ts',
+	};
+
+	function setup(file: keyof typeof filesMap) {
+		tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+		tree.write('package.json', `{"dependencies": {"@angular/core": "17.3.0"}}`);
+		tree.write(`libs/my-file.ts`, filesMap[file]);
+
+		return () => {
+			return [tree.read('libs/my-file.ts', 'utf8'), filesMap[file]];
+		};
+	}
+
+	it('should not do anything if not component/directive', async () => {
+		const readContent = setup('notComponentNorDirective');
+		await convertOutputsGenerator(tree, options);
+		const [updated, original] = readContent();
+		expect(updated).toEqual(original);
+	});
+
+	it('should not do anything if no input', async () => {
+		const readContent = setup('componentNoOutput');
+		await convertOutputsGenerator(tree, options);
+		const [updated, original] = readContent();
+		expect(updated).toEqual(original);
+	});
+
+	it('should convert properly', async () => {
+		const readContent = setup('component');
+		await convertOutputsGenerator(tree, options);
+		const [updated] = readContent();
+		expect(updated).toMatchSnapshot();
+	});
+
+	it('should not add outputFromObservable import if not needed', async () => {
+		const readContent = setup('outputWithoutObservable');
+		await convertOutputsGenerator(tree, options);
+		const [updated] = readContent();
+		expect(updated).toMatchSnapshot();
+	});
+});

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -120,7 +120,7 @@ function getOutputInitializer(
 			// there is no type
 		} else {
 			const genericTypeOnEmitter = initializer.match(/EventEmitter<(.+)>/);
-			if (genericTypeOnEmitter.length) {
+			if (genericTypeOnEmitter?.length) {
 				type = genericTypeOnEmitter[1];
 			}
 		}

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -1,0 +1,274 @@
+import {
+	Tree,
+	formatFiles,
+	getProjects,
+	logger,
+	readJson,
+	readProjectConfiguration,
+	visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { readFileSync } from 'node:fs';
+import { exit } from 'node:process';
+import {
+	CodeBlockWriter,
+	Decorator,
+	Node,
+	Project,
+	WriterFunction,
+} from 'ts-morph';
+import { ConvertOutputsGeneratorSchema } from './schema';
+
+class ContentsStore {
+	private _project: Project = null!;
+
+	collection: Array<{ path: string; content: string }> = [];
+
+	get project() {
+		if (!this._project) {
+			this._project = new Project({ useInMemoryFileSystem: true });
+		}
+
+		return this._project;
+	}
+
+	track(path: string, content: string) {
+		this.collection.push({ path, content });
+		this.project.createSourceFile(path, content);
+	}
+}
+
+function trackContents(
+	tree: Tree,
+	contentsStore: ContentsStore,
+	fullPath: string,
+) {
+	if (fullPath.endsWith('.ts')) {
+		const fileContent =
+			tree.read(fullPath, 'utf8') || readFileSync(fullPath, 'utf8');
+		if (
+			!fileContent.includes('@Component') &&
+			!fileContent.includes('@Directive')
+		) {
+			logger.error(
+				`[ngxtension] "${fullPath}" is not a Component nor a Directive`,
+			);
+			return;
+		}
+
+		if (
+			fileContent.includes('@Output') &&
+			fileContent.includes('EventEmitter')
+		) {
+			contentsStore.track(fullPath, fileContent);
+		}
+	}
+}
+
+function getOutputInitializer(
+	decorator: Decorator,
+	initializer: string,
+): {
+	needsOutputFromObservableImport: boolean;
+	writerFn: WriterFunction;
+} {
+	const decoratorArg = decorator.getArguments()[0];
+
+	// get alias if there is any from the decorator
+	let alias: string | undefined = undefined;
+	if (Node.isStringLiteral(decoratorArg)) {
+		alias = decoratorArg.getText();
+	}
+
+	// check if the initializer is not an EventEmitter -> means its an observable
+	if (!initializer.includes('EventEmitter')) {
+		return {
+			writerFn: (writer: CodeBlockWriter) => {
+				writer.write(`outputFromObservable`);
+				writer.write(`(${initializer}`);
+				writer.write(`${alias ? `, { alias: ${alias} }` : ''}`);
+				writer.write(`);`);
+			},
+			needsOutputFromObservableImport: true,
+		};
+	} else {
+		let type = '';
+		if (initializer.includes('new EventEmitter()')) {
+			// there is no type
+		} else {
+			const genericTypeOnEmitter = initializer.match(/EventEmitter<(.+)>/);
+			if (genericTypeOnEmitter.length) {
+				type = genericTypeOnEmitter[1];
+			}
+		}
+
+		return {
+			writerFn: (writer: CodeBlockWriter) => {
+				writer.write(`output`);
+				writer.write(`${type ? `<${type}>` : ''}(`);
+				writer.write(`${alias ? `, { alias: ${alias} }` : ''}`);
+				writer.write(`);`);
+			},
+			needsOutputFromObservableImport: false,
+		};
+	}
+}
+
+export async function convertOutputsGenerator(
+	tree: Tree,
+	options: ConvertOutputsGeneratorSchema,
+) {
+	const contentsStore = new ContentsStore();
+	const packageJson = readJson(tree, 'package.json');
+	const angularCorePackage = packageJson['dependencies']['@angular/core'];
+
+	if (!angularCorePackage) {
+		logger.error(`[ngxtension] No @angular/core detected`);
+		return exit(1);
+	}
+
+	const [major, minor] = angularCorePackage
+		.split('.')
+		.slice(0, 2)
+		.map((part: string) => {
+			if (part.startsWith('^') || part.startsWith('~')) {
+				return Number(part.slice(1));
+			}
+			return Number(part);
+		});
+
+	if (major < 17 || (major >= 17 && minor < 3)) {
+		logger.error(`[ngxtension] output() is only available in v17.3 and later`);
+		return exit(1);
+	}
+
+	const { path, project } = options;
+
+	if (path && project) {
+		logger.error(
+			`[ngxtension] Cannot pass both "path" and "project" to convertOutputsGenerator`,
+		);
+		return exit(1);
+	}
+
+	if (path) {
+		if (!tree.exists(path)) {
+			logger.error(`[ngxtension] "${path}" does not exist`);
+			return exit(1);
+		}
+
+		trackContents(tree, contentsStore, path);
+	} else if (project) {
+		try {
+			const projectConfiguration = readProjectConfiguration(tree, project);
+
+			if (!projectConfiguration) {
+				throw `"${project}" project not found`;
+			}
+
+			visitNotIgnoredFiles(tree, projectConfiguration.root, (path) => {
+				trackContents(tree, contentsStore, path);
+			});
+		} catch (err) {
+			logger.error(`[ngxtension] ${err}`);
+			return;
+		}
+	} else {
+		const projects = getProjects(tree);
+		for (const project of projects.values()) {
+			visitNotIgnoredFiles(tree, project.root, (path) => {
+				trackContents(tree, contentsStore, path);
+			});
+		}
+	}
+
+	for (const { path: sourcePath } of contentsStore.collection) {
+		const sourceFile = contentsStore.project.getSourceFile(sourcePath);
+
+		const hasOutputImport = sourceFile.getImportDeclaration(
+			(importDecl) =>
+				importDecl.getModuleSpecifierValue() === '@angular/core' &&
+				importDecl
+					.getNamedImports()
+					.some((namedImport) => namedImport.getName() === 'output'),
+		);
+
+		// NOTE: only add hasOutputImport import if we don't have it and we find the first Output decorator
+		if (!hasOutputImport) {
+			sourceFile.addImportDeclaration({
+				namedImports: ['output'],
+				moduleSpecifier: '@angular/core',
+			});
+		}
+
+		const classes = sourceFile.getClasses();
+
+		for (const targetClass of classes) {
+			const applicableDecorator = targetClass.getDecorator((decoratorDecl) => {
+				return ['Component', 'Directive'].includes(decoratorDecl.getName());
+			});
+			if (!applicableDecorator) continue;
+
+			const convertedOutputs = new Set<string>();
+
+			const outputFromObservableImportAdded = false;
+
+			targetClass.forEachChild((node) => {
+				if (Node.isPropertyDeclaration(node)) {
+					const outputDecorator = node.getDecorator('Output');
+					if (outputDecorator) {
+						const {
+							name,
+							isReadonly,
+							docs,
+							scope,
+							hasOverrideKeyword,
+							initializer,
+						} = node.getStructure();
+
+						const { needsOutputFromObservableImport, writerFn } =
+							getOutputInitializer(outputDecorator, initializer as string);
+
+						if (
+							needsOutputFromObservableImport &&
+							!outputFromObservableImportAdded
+						) {
+							sourceFile.addImportDeclaration({
+								namedImports: ['outputFromObservable'],
+								moduleSpecifier: '@angular/core/rxjs-interop',
+							});
+						}
+
+						const newProperty = targetClass.addProperty({
+							name,
+							isReadonly,
+							docs,
+							scope,
+							hasOverrideKeyword,
+							initializer: writerFn,
+						});
+
+						node.replaceWithText(newProperty.print());
+
+						// remove old class property Output
+						newProperty.remove();
+
+						// track converted outputs
+						convertedOutputs.add(name);
+					}
+				}
+			});
+		}
+
+		tree.write(sourcePath, sourceFile.getFullText());
+	}
+
+	await formatFiles(tree);
+
+	logger.info(
+		`
+[ngxtension] Conversion completed. Please check the content and run your formatter as needed.
+`,
+	);
+}
+
+export default convertOutputsGenerator;

--- a/libs/plugin/src/generators/convert-outputs/schema.d.ts
+++ b/libs/plugin/src/generators/convert-outputs/schema.d.ts
@@ -1,0 +1,4 @@
+export interface ConvertOutputsGeneratorSchema {
+	project?: string;
+	path?: string;
+}

--- a/libs/plugin/src/generators/convert-outputs/schema.json
+++ b/libs/plugin/src/generators/convert-outputs/schema.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "http://json-schema.org/schema",
+	"$id": "",
+	"title": "",
+	"type": "object",
+	"properties": {
+		"project": {
+			"type": "string",
+			"aliases": ["name", "projectName"],
+			"description": "Project for which to convert to new outputs."
+		},
+		"path": {
+			"type": "string",
+			"description": "Path to the component/directive you want to convert to use new outputs"
+		}
+	}
+}


### PR DESCRIPTION
Added migration support for: 

- EventEmitters -> output
- Observable/Subject/BehaviorSubject -> outputFromObservable

+ support for aliases 
+ docs 