### PR TITLE
feat(inject-route-fragment): implementation of injectRouteFragment

### DIFF
--- a/docs/src/content/docs/utilities/Injectors/inject-route-fragment.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-route-fragment.md
@@ -1,0 +1,39 @@
+---
+title: injectRouteFragment
+description: ngxtension/inject-route-fragment
+entryPoint: inject-route-fragment
+contributors: ['krzysztof-kachniarz']
+---
+
+`injectRouteFragment` is a helper function that allows you to inject url fragment from the current route as a signal.
+
+```ts
+import { injectRouteFragment } from 'ngxtension/inject-route-fragment';
+```
+
+## Usage
+
+`injectRouteFragment` when is called, returns a signal with the current route fragment.
+
+```ts
+@Component(...)
+class TestComponent {
+  fragment = injectRouteFragment();
+}
+```
+
+You can pass transform function or custom injector.
+
+```ts
+@Component()
+class TestComponent implements OnInit {
+	injector = inject(Injector);
+
+	ngOnInit() {
+		const isFragmentAvailable: Signal<boolean> = injectRouteFragment({
+			transform: (fragment) => !!fragment,
+			injector: this.injector,
+		});
+	}
+}
+```

--- a/libs/ngxtension/inject-route-fragment/README.md
+++ b/libs/ngxtension/inject-route-fragment/README.md
@@ -1,0 +1,3 @@
+# ngxtension/inject-route-fragment
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/inject-route-fragment`.

--- a/libs/ngxtension/inject-route-fragment/ng-package.json
+++ b/libs/ngxtension/inject-route-fragment/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/inject-route-fragment/project.json
+++ b/libs/ngxtension/inject-route-fragment/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/inject-route-fragment",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/inject-route-fragment/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["inject-route-fragment"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/inject-route-fragment/src/index.ts
+++ b/libs/ngxtension/inject-route-fragment/src/index.ts
@@ -1,0 +1,1 @@
+export * from './inject-route-fragment';

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
@@ -1,0 +1,59 @@
+import { Component, inject, Injector, OnInit, Signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { injectRouteFragment } from './inject-route-fragment';
+
+describe(injectRouteFragment.name, () => {
+	it('returns a signal everytime the route fragment changed', async () => {
+		TestBed.configureTestingModule({
+			providers: [
+				provideRouter([
+					{
+						path: 'test',
+						component: TestComponent,
+					},
+				]),
+			],
+		});
+
+		const harness = await RouterTestingHarness.create();
+
+		const instance = await harness.navigateByUrl('test', TestComponent);
+
+		expect(instance.fragment()).toEqual(null);
+		expect(instance.fragmentFromCustomInjector).not.toBeNull();
+		if (instance.fragmentFromCustomInjector) {
+			expect(instance.fragmentFromCustomInjector()).toEqual(null);
+		}
+		expect(instance.isFragmentAvailable()).toEqual(false);
+
+		await harness.navigateByUrl('test#sample-fragment', TestComponent);
+
+		expect(instance.fragment()).toEqual('sample-fragment');
+		expect(instance.fragmentFromCustomInjector).not.toBeNull();
+		if (instance.fragmentFromCustomInjector) {
+			expect(instance.fragmentFromCustomInjector()).toEqual('sample-fragment');
+		}
+		expect(instance.isFragmentAvailable()).toEqual(true);
+	});
+});
+
+@Component({
+	standalone: true,
+	template: ``,
+})
+export class TestComponent implements OnInit {
+	private _injector = inject(Injector);
+	fragment = injectRouteFragment();
+	isFragmentAvailable = injectRouteFragment({
+		transform: (fragment) => !!fragment,
+	});
+	fragmentFromCustomInjector: Signal<string | null> | null = null;
+
+	ngOnInit() {
+		this.fragmentFromCustomInjector = injectRouteFragment({
+			injector: this._injector,
+		});
+	}
+}

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
@@ -1,0 +1,55 @@
+import { inject, type Injector, type Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { assertInjector } from 'ngxtension/assert-injector';
+import { map } from 'rxjs';
+
+export interface InjectRouteFragmentOptions<T = unknown> {
+	/**
+	 * A transformation function.
+	 *
+	 * @param fragment - The fragment value to transform.
+	 * @returns The transformed value.
+	 */
+	transform?: (fragment: string | null) => T;
+
+	/**
+	 * The optional "custom" Injector. If this is not provided, will be retrieved from the current injection context
+	 */
+	injector?: Injector;
+}
+
+/**
+ * The `injectRouteFragment` function allows you to access and transform url fragment from the current route.
+ *
+ * @returns {Signal} A `Signal` that emits the route fragment.
+ */
+export function injectRouteFragment(): Signal<string | null>;
+
+/**
+ * The `injectRouteFragment` function allows you to access and transform url fragment from the current route.
+ *
+ * @param {InjectRouteFragmentOptions} options - inject options like transform fn.
+ * @returns {Signal} A `Signal` that emits the transformed value of url fragment.
+ */
+export function injectRouteFragment<T>(
+	options: InjectRouteFragmentOptions<T>,
+): Signal<T>;
+
+export function injectRouteFragment<T>(
+	options?: InjectRouteFragmentOptions<T>,
+) {
+	return assertInjector(injectRouteFragment, options?.injector, () => {
+		const route = inject(ActivatedRoute);
+		const initialRouteFragment = route.snapshot.fragment;
+		const getFragment = (fragment: string | null) => {
+			if (options?.transform) return options.transform(fragment);
+			return fragment;
+		};
+		const fragment$ = route.fragment.pipe(map(getFragment));
+
+		return toSignal(fragment$, {
+			initialValue: getFragment(initialRouteFragment),
+		});
+	});
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -89,6 +89,9 @@
 			"ngxtension/inject-route-data": [
 				"libs/ngxtension/inject-route-data/src/index.ts"
 			],
+			"ngxtension/inject-route-fragment": [
+				"libs/ngxtension/inject-route-fragment/src/index.ts"
+			],
 			"ngxtension/intl": ["libs/ngxtension/intl/src/index.ts"],
 			"ngxtension/map-array": ["libs/ngxtension/map-array/src/index.ts"],
 			"ngxtension/map-skip-undefined": [


### PR DESCRIPTION
PR adds a injectRouteFragment() injector.

```ts
@Component()
class TestComponent implements OnInit {
  injector = inject(Injector);
  fragment: Signal<string | null> = injectRouteFragment();

  ngOnInit() {
    const isFragmentAvailable: Signal<boolean> = injectRouteFragment({
      transform: (fragment) => !!fragment,
      injector: this.injector,
    });
  }
}
```