### PR TITLE
docs: contributor badges fixes

### DIFF
--- a/docs/src/components/Contributors.astro
+++ b/docs/src/components/Contributors.astro
@@ -24,26 +24,28 @@ const { contributors } = Astro.props;
 			({ data: { name, twitter, linkedin, github, website } }) => (
 				<span class="contributor">
 					{name}
-					{twitter && (
-						<a href={twitter}>
-							<Icon class="icon" name="twitter" size="0.75rem" />
-						</a>
-					)}
-					{linkedin && (
-						<a href={linkedin}>
-							<Icon class="icon" name="linkedin" size="0.75rem" />
-						</a>
-					)}
-					{github && (
-						<a href={github}>
-							<Icon class="icon" name="github" size="0.75rem" />
-						</a>
-					)}
-					{website && (
-						<a href={website}>
-							<Icon class="icon" name="external" size="0.75rem" />
-						</a>
-					)}
+					<span class="icons">
+						{twitter && (
+							<a href={twitter} aria-label="Open {name}'s Twitter account">
+								<Icon class="icon" name="twitter" size="0.75rem" />
+							</a>
+						)}
+						{linkedin && (
+							<a href={linkedin} aria-label="Open {name}'s LinkedIn account">
+								<Icon class="icon" name="linkedin" size="0.75rem" />
+							</a>
+						)}
+						{github && (
+							<a href={github} aria-label="Open {name}'s GitHub account">
+								<Icon class="icon" name="github" size="0.75rem" />
+							</a>
+						)}
+						{website && (
+							<a href={website} aria-label="Open {name}'s website">
+								<Icon class="icon" name="external" size="0.75rem" />
+							</a>
+						)}
+					</span>
 				</span>
 			),
 		)
@@ -58,6 +60,7 @@ const { contributors } = Astro.props;
 	.contributors {
 		display: flex;
 		gap: 0.3rem;
+		flex-wrap: wrap;
 		align-items: center;
 		margin-top: -1rem;
 		font-size: var(--sl-text-xs);
@@ -68,9 +71,17 @@ const { contributors } = Astro.props;
 		background-color: var(--sl-color-gray-6);
 		border-radius: 6px;
 		padding: 2px 8px;
+		display: flex;
+		gap: 0.475rem;
+	}
+
+	.icons {
+		display: flex;
+		gap: 0.25rem;
 	}
 
 	.icon {
+		margin-top: -2px;
 		vertical-align: middle;
 		color: var(--sl-color-gray-3);
 

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -8,6 +8,7 @@ const contributors = defineCollection({
 		twitter: z.string().url().optional(),
 		linkedin: z.string().url().optional(),
 		github: z.string().url().optional(),
+		website: z.string().url().optional(),
 	}),
 });
 


### PR DESCRIPTION
Before:
![before](https://github.com/nartc/ngxtension-platform/assets/16242839/242dc9ca-ecd3-4c0b-8a58-98de3ec9a748)
![before2](https://github.com/nartc/ngxtension-platform/assets/16242839/3c493561-107f-4211-b816-bae41f83cb78)

After:
![after](https://github.com/nartc/ngxtension-platform/assets/16242839/9cd52266-8651-4d3d-b267-11f5e3d6aa42)
![after2](https://github.com/nartc/ngxtension-platform/assets/16242839/8d33904b-f028-454b-9121-14f8d09cf3ba)

Also add the missing website property to the contributors collection.

Feel free to dismiss :)

