### PR TITLE
feat(output-migration): enhancements

### DIFF
--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -13,6 +13,11 @@ export class MyCmp {
   someObservable$ = of('test');
 
   outputWithoutType = output();
+
+  protected outputWithPrivateScope = output();
+  protected outputWithProtectedScope = output();
+  public outputWithPublicScope = output();
+
   normalOutput = output<string>();
 
   someOutput = output<DataInterface>();
@@ -44,6 +49,9 @@ export class MyCmp {
     _outputFromSubject = outputFromObservable(this.outputFromSubject, { alias: 'outputFromSubject' });
     /** TODO(migration): you may want to convert this to a normal output */
     _outputFromBehaviorSubject = outputFromObservable(this.outputFromBehaviorSubject, { alias: 'outputFromBehaviorSubject' });
+;
+;
+;
 ;
 ;
 ;

--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -2,9 +2,8 @@
 
 exports[`convertOutputsGenerator should convert properly 1`] = `
 "
-import { Component } from '@angular/core';
-import { output } from "@angular/core";
-import { outputFromObservable } from "@angular/core/rxjs-interop";
+import { Component, output } from '@angular/core';
+import { toSignal, outputFromObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   template: \` \`
@@ -66,8 +65,7 @@ export class MyCmp {
 
 exports[`convertOutputsGenerator should not add outputFromObservable import if not needed 1`] = `
 "
-import { Component } from '@angular/core';
-import { output } from "@angular/core";
+import { Component, output } from '@angular/core';
 
 @Component({
   template: \` \`

--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`convertOutputsGenerator should convert properly 1`] = `
 "
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component } from '@angular/core';
 import { output } from "@angular/core";
 import { outputFromObservable } from "@angular/core/rxjs-interop";
 
@@ -14,6 +14,8 @@ export class MyCmp {
 
   outputWithoutType = output();
   normalOutput = output<string>();
+
+  someOutput = output<DataInterface>();
 
   normalOutput2 = output<string>();
 
@@ -49,13 +51,14 @@ export class MyCmp {
 ;
 ;
 ;
+;
 }
 "
 `;
 
 exports[`convertOutputsGenerator should not add outputFromObservable import if not needed 1`] = `
 "
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component } from '@angular/core';
 import { output } from "@angular/core";
 
 @Component({

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -38,6 +38,11 @@ export class MyCmp {
   someObservable$ = of('test');
 
   @Output() outputWithoutType = new EventEmitter();
+
+  @Output() private outputWithPrivateScope = new EventEmitter();
+  @Output() protected outputWithProtectedScope = new EventEmitter();
+  @Output() public outputWithPublicScope = new EventEmitter();
+
   @Output() normalOutput = new EventEmitter<string>();
 
   @Output() someOutput: EventEmitter<DataInterface> = new EventEmitter();

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -40,6 +40,8 @@ export class MyCmp {
   @Output() outputWithoutType = new EventEmitter();
   @Output() normalOutput = new EventEmitter<string>();
 
+  @Output() someOutput: EventEmitter<DataInterface> = new EventEmitter();
+
   @Output() normalOutput2: EventEmitter<string> = new EventEmitter<string>();
 
   @Output() outputFromSubject = new Subject();
@@ -66,7 +68,7 @@ export class MyCmp {
 `,
 } as const;
 
-fdescribe('convertOutputsGenerator', () => {
+describe('convertOutputsGenerator', () => {
 	let tree: Tree;
 	const options: ConvertOutputsGeneratorSchema = {
 		path: 'libs/my-file.ts',

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -30,6 +30,7 @@ export class MyCmp {
 `,
 	component: `
 import { Component, Output, EventEmitter } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   template: \` \`

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -230,10 +230,19 @@ export async function convertOutputsGenerator(
 
 		// NOTE: only add hasOutputImport import if we don't have it and we find the first Output decorator
 		if (!hasOutputImport) {
-			sourceFile.addImportDeclaration({
-				namedImports: ['output'],
-				moduleSpecifier: '@angular/core',
-			});
+			const angularCoreImports = sourceFile.getImportDeclaration(
+				(importDecl) => {
+					return importDecl.getModuleSpecifierValue() === '@angular/core';
+				},
+			);
+			if (angularCoreImports) {
+				angularCoreImports.addNamedImport('output');
+			} else {
+				sourceFile.addImportDeclaration({
+					namedImports: ['output'],
+					moduleSpecifier: '@angular/core',
+				});
+			}
 		}
 
 		const classes = sourceFile.getClasses();
@@ -278,10 +287,25 @@ export async function convertOutputsGenerator(
 							needsOutputFromObservableImport &&
 							!outputFromObservableImportAdded
 						) {
-							sourceFile.addImportDeclaration({
-								namedImports: ['outputFromObservable'],
-								moduleSpecifier: '@angular/core/rxjs-interop',
-							});
+							const angularRxjsInteropImports = sourceFile.getImportDeclaration(
+								(importDecl) => {
+									return (
+										importDecl.getModuleSpecifierValue() ===
+										'@angular/core/rxjs-interop'
+									);
+								},
+							);
+							if (angularRxjsInteropImports) {
+								angularRxjsInteropImports.addNamedImport(
+									'outputFromObservable',
+								);
+							} else {
+								sourceFile.addImportDeclaration({
+									namedImports: ['outputFromObservable'],
+									moduleSpecifier: '@angular/core/rxjs-interop',
+								});
+							}
+
 							outputFromObservableImportAdded = true;
 						}
 

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -63,6 +63,7 @@ function trackContents(
 
 function getOutputInitializer(
 	propertyName: string,
+	currentType: string | WriterFunction,
 	decorator: Decorator,
 	initializer: string,
 ): {
@@ -119,6 +120,13 @@ function getOutputInitializer(
 			const genericTypeOnEmitter = initializer.match(/EventEmitter<(.+)>/);
 			if (genericTypeOnEmitter?.length) {
 				type = genericTypeOnEmitter[1];
+			}
+		}
+
+		if (typeof currentType === 'string') {
+			const genericTypeOnType = currentType.match(/EventEmitter<(.+)>/);
+			if (genericTypeOnType?.length) {
+				type = genericTypeOnType[1];
 			}
 		}
 
@@ -242,6 +250,7 @@ export async function convertOutputsGenerator(
 							isReadonly,
 							docs,
 							scope,
+							type,
 							hasOverrideKeyword,
 							initializer,
 						} = node.getStructure();
@@ -253,6 +262,7 @@ export async function convertOutputsGenerator(
 							writerFn,
 						} = getOutputInitializer(
 							name,
+							type,
 							outputDecorator,
 							initializer as string,
 						);

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -1,10 +1,10 @@
 import {
-	Tree,
 	formatFiles,
 	getProjects,
 	logger,
 	readJson,
 	readProjectConfiguration,
+	Tree,
 	visitNotIgnoredFiles,
 } from '@nx/devkit';
 import { readFileSync } from 'node:fs';
@@ -14,6 +14,7 @@ import {
 	Decorator,
 	Node,
 	Project,
+	Scope,
 	WriterFunction,
 } from 'ts-morph';
 import { ConvertOutputsGeneratorSchema } from './schema';
@@ -288,7 +289,8 @@ export async function convertOutputsGenerator(
 							name: outputName ?? name,
 							isReadonly,
 							docs,
-							scope,
+							// we want to keep the scope as protected if it was private in order to avoid breaking changes
+							scope: scope === Scope.Private ? Scope.Protected : scope,
 							hasOverrideKeyword,
 							initializer: writerFn,
 						});


### PR DESCRIPTION
- [x] remove `Output` and `EventEmitter` from imports if not used anymore
- [x] append `output`/`outputFromObservable` to existing import from angular/core
- [x] replace `private` with `protected` for outputs to not break existing private scope usages
- [x] migrate the following case correctly
```typescript
@Output() someOutput: EventEmitter<DataInterface> = new EventEmitter();

// currently
someOutput = output();

// should be
someOutput = output<DataInterface>();
```

Closes https://github.com/nartc/ngxtension-platform/issues/312