### PR TITLE
feat: add debounceSignal

### DIFF
--- a/libs/ngxtension/debounce-signal/README.md
+++ b/libs/ngxtension/debounce-signal/README.md
@@ -1,0 +1,3 @@
+# ngxtension/debounce-signal
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/debounce-signal`.

--- a/libs/ngxtension/debounce-signal/ng-package.json
+++ b/libs/ngxtension/debounce-signal/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/debounce-signal/project.json
+++ b/libs/ngxtension/debounce-signal/project.json
@@ -1,0 +1,20 @@
+{
+	"name": "ngxtension/debounce-signal",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/debounce-signal/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["debounce-signal"]
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/debounce-signal/src/debounce-signal.spec.ts
+++ b/libs/ngxtension/debounce-signal/src/debounce-signal.spec.ts
@@ -1,0 +1,178 @@
+import { TestBed } from '@angular/core/testing';
+import { debounceSignal } from './debounce-signal';
+
+describe(debounceSignal.name, () => {
+	describe('data types', () => {
+		beforeEach(() => {
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+			jest.clearAllMocks();
+		});
+
+		it('number', () => {
+			TestBed.runInInjectionContext(() => {
+				const s = debounceSignal(1, 300);
+
+				expect(s()).toEqual(1);
+				s.set(2);
+				expect(s()).toEqual(1);
+
+				jest.advanceTimersByTime(301);
+				expect(s()).toEqual(2);
+			});
+		});
+
+		it('multiple changes number', () => {
+			TestBed.runInInjectionContext(() => {
+				const s = debounceSignal(1, 300);
+
+				expect(s()).toEqual(1);
+				s.set(2);
+				s.set(3);
+				s.set(4);
+				expect(s()).toEqual(1);
+
+				jest.advanceTimersByTime(301);
+				expect(s()).toEqual(4);
+			});
+		});
+
+		it('string', () => {
+			TestBed.runInInjectionContext(() => {
+				const s = debounceSignal('1', 300);
+
+				expect(s()).toEqual('1');
+				s.set('2');
+				expect(s()).toEqual('1');
+
+				jest.advanceTimersByTime(301);
+				expect(s()).toEqual('2');
+			});
+		});
+
+		it('multiple changes string', () => {
+			TestBed.runInInjectionContext(() => {
+				const s = debounceSignal('1', 300);
+
+				expect(s()).toEqual('1');
+				s.set('2');
+				s.set('3');
+				s.set('4');
+				expect(s()).toEqual('1');
+
+				jest.advanceTimersByTime(301);
+				expect(s()).toEqual('4');
+			});
+		});
+
+		it('should handle immediate updates followed by debounced updates', () => {
+			TestBed.runInInjectionContext(() => {
+				const s = debounceSignal(1, 300);
+				expect(s()).toBe(1);
+
+				s.set(2);
+				expect(s()).toBe(1);
+
+				jest.advanceTimersByTime(150);
+				s.set(3);
+				expect(s()).toBe(1);
+
+				jest.advanceTimersByTime(151);
+				expect(s()).toBe(1);
+
+				jest.advanceTimersByTime(150);
+				expect(s()).toBe(3);
+			});
+		});
+
+		it('object', () => {
+			TestBed.runInInjectionContext(() => {
+				const initialObject = { a: 1, b: { c: 2 } };
+				const s = debounceSignal(initialObject, 300);
+
+				expect(s()).toEqual(initialObject);
+
+				const updatedObject = { a: 2, b: { c: 3 } };
+				s.set(updatedObject);
+				expect(s()).toEqual(initialObject);
+
+				jest.advanceTimersByTime(301);
+				expect(s()).toEqual(updatedObject);
+			});
+		});
+
+		it('array', () => {
+			TestBed.runInInjectionContext(() => {
+				const initialArray = [1, 2, 3];
+				const s = debounceSignal(initialArray, 300);
+
+				expect(s()).toEqual(initialArray);
+
+				const updatedArray = [4, 5, 6];
+				s.set(updatedArray);
+				expect(s()).toEqual(initialArray);
+
+				jest.advanceTimersByTime(301);
+				expect(s()).toEqual(updatedArray);
+			});
+		});
+
+		it('nested object property', () => {
+			TestBed.runInInjectionContext(() => {
+				const initialObject = { a: 1, b: { c: 2 } };
+				const s = debounceSignal(initialObject, 300);
+
+				expect(s().b.c).toEqual(2);
+
+				s.update((val) => ({ ...val, b: { ...val.b, c: 3 } }));
+
+				expect(s().b.c).toEqual(2);
+
+				jest.advanceTimersByTime(301);
+				expect(s().b.c).toEqual(3);
+			});
+		});
+
+		it('multiple changes to nested object property', () => {
+			TestBed.runInInjectionContext(() => {
+				const initialObject = { a: 1, b: { c: 2 } };
+				const s = debounceSignal(initialObject, 300);
+
+				expect(s().b.c).toEqual(2);
+
+				s.update((val) => ({ ...val, b: { ...val.b, c: 3 } }));
+				s.update((val) => ({ ...val, b: { ...val.b, c: 4 } }));
+				s.update((val) => ({ ...val, b: { ...val.b, c: 5 } }));
+
+				expect(s().b.c).toEqual(2);
+
+				jest.advanceTimersByTime(301);
+				expect(s().b.c).toEqual(5);
+			});
+		});
+
+		it('No support change the internal object but changes work', () => {
+			TestBed.runInInjectionContext(() => {
+				const initialObject = { a: 1, b: { c: 2 } };
+				const s = debounceSignal(initialObject, 300);
+
+				initialObject.b.c = 5;
+				expect(s().b.c).toEqual(5);
+
+				s.update((x) => {
+					x.b.c = 100;
+					return x;
+				});
+
+				expect(s().b.c).toEqual(5);
+
+				jest.advanceTimersByTime(301);
+
+				expect(s().b.c).toEqual(100);
+			});
+		});
+	});
+});

--- a/libs/ngxtension/debounce-signal/src/debounce-signal.ts
+++ b/libs/ngxtension/debounce-signal/src/debounce-signal.ts
@@ -1,0 +1,37 @@
+import { CreateSignalOptions, WritableSignal } from '@angular/core';
+import {
+	SIGNAL,
+	SignalGetter,
+	signalSetFn,
+	signalUpdateFn,
+} from '@angular/core/primitives/signals';
+import { createSignal } from 'ngxtension/create-signal';
+
+export function debounceSignal<T>(
+	initialValue: T,
+	time: number,
+	options?: CreateSignalOptions<T>,
+): WritableSignal<T> {
+	const signalFn = createSignal(initialValue) as SignalGetter<T> &
+		WritableSignal<T>;
+	const node = signalFn[SIGNAL];
+	if (options?.equal) {
+		node.equal = options.equal;
+	}
+
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	signalFn.set = (newValue: T) => {
+		clearTimeout(timeoutId);
+
+		timeoutId = setTimeout(() => signalSetFn(node, newValue), time);
+	};
+
+	signalFn.update = (updateFn: (value: T) => T) => {
+		clearTimeout(timeoutId);
+
+		timeoutId = setTimeout(() => signalUpdateFn(node, updateFn), time);
+	};
+
+	return signalFn;
+}

--- a/libs/ngxtension/debounce-signal/src/index.ts
+++ b/libs/ngxtension/debounce-signal/src/index.ts
@@ -1,0 +1,1 @@
+export * from './debounce-signal';


### PR DESCRIPTION
## Description
Currently it takes quite a bit of code to implement debounces in signal land if you wanna move towards becoming undependant on rxjs so the idea is to have a signal primitive that has debounce built in

This approach has an important drawback:

It uses a lot of the internals of the signal implementation that could break should the angular team decide to change the base implementation of signals. Then this would need to be updated as well

### Proposed API
```typescript
debounceSignal<T>(
    initialValue: T,
    time: number,
    options?: CreateSignalOptions<T>,
): WritableSignal<T>
```

### Usage example
```
// in component
example = debounceSignal('', 300)

ngOnInit() {
  this.example.set('hello') // 300ms after this are reacted to on all listeners
}

// in markup
<input type="text" [(ngModel)]="example" />

<pre>{{ example() }}</pre>
```

Worth noting it also works with all data types ex `string`, `number`, `array`, `object` also nested values i wanna emphasise this test fx for nested objects 

```typescript
const initialObject = { a: 1, b: { c: 2 } };
const s = debounceSignal(initialObject, 300);

expect(s().b.c).toEqual(2);

s.update((val) => ({ ...val, b: { ...val.b, c: 3 } }));
s.update((val) => ({ ...val, b: { ...val.b, c: 4 } }));
s.update((val) => ({ ...val, b: { ...val.b, c: 5 } }));

expect(s().b.c).toEqual(2);

jest.advanceTimersByTime(301);
expect(s().b.c).toEqual(5);
```

## Benefits:

More intuitive API for when having to debounce values
Clearer code intention
Easier to understand