### PR TITLE
fix: use removeChild() loop instead of replaceChildren()

### DIFF
--- a/libs/ngxtension/svg-sprite/src/svg-sprite.ts
+++ b/libs/ngxtension/svg-sprite/src/svg-sprite.ts
@@ -379,7 +379,9 @@ export class NgxSvgSpriteFragment implements OnInit {
 
 			// Cleanup: clear child nodes and remove old classes of this svg.
 			return () => {
-				element.replaceChildren();
+        while (element.firstChild) {
+            element.removeChild(element.firstChild);
+        }
 				element.classList.remove(...classes);
 			};
 		});


### PR DESCRIPTION
In local development with Angular v20.2-next I was not able to use the SvgSprite Directive as it fails on the server with `element.replaceChildren is not defined`. Checking the Node.JS documentation `replaceChildren()` is only available in environments that supports DOM manipulation, such as a browser or a server-side rendering library that provides DOM-like APIs.

This fix uses a while loop to remove all children one by one ensuring its also working in such environments.