### PR TITLE
feat: add injectAttribute utility

### DIFF
--- a/docs/src/content/contributors/skyzerozx.json
+++ b/docs/src/content/contributors/skyzerozx.json
@@ -1,0 +1,6 @@
+{
+	"name": "Jaime Burgos",
+	"linkedin": "https://www.linkedin.com/in/jaime-burgos-tejada-a45697203/",
+	"github": "https://github.com/SkyZeroZx",
+	"website": "https://skyzerozx.com/"
+}

--- a/docs/src/content/docs/utilities/Injectors/inject-attribute.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-attribute.md
@@ -1,0 +1,83 @@
+---
+title: injectAttribute
+description: ngxtension/inject-attribute
+entryPoint: ngxtension/inject-attribute
+badge: stable
+contributors: ['SkyZeroZx']
+---
+
+`injectAttribute` is a small utility built on top of `HostAttributeToken` that lets you read host attributes through `inject()`.  
+It's ideal for **static, initialization-time configuration**, since—unlike `input()` attributes are resolved **once** and never updated later.
+
+```ts
+import { injectAttribute } from 'ngxtension/inject-attribute';
+```
+
+## Usage
+
+### Basic usage with default value
+
+```ts
+@Component({
+	selector: 'app-divider',
+	standalone: true,
+})
+class Divider {
+	size = injectAttribute('size', 'sm');
+}
+```
+
+```html
+<app-divider size="lg" />
+```
+
+If the `size` attribute is not provided, it defaults to `'sm'`.
+
+### Required attributes
+
+Use `injectAttribute.required()` when an attribute must be provided:
+
+```ts
+@Component({
+	selector: 'app-card',
+	standalone: true,
+})
+class Card {
+	variation = injectAttribute.required<string>('variation');
+}
+```
+
+```html
+<app-card variation="primary"></app-card>
+```
+
+If the attribute is missing, Angular throws an error: `NG0201: No provider for HostAttributeToken variation found`
+
+### Type coercion with transform
+
+Since host attributes are always strings, use the `transform` option to convert them to other types:
+
+```ts
+const numberAttribute = (value: string) => Number(value);
+const booleanAttribute = (value: string) => value !== null;
+
+@Component({
+	selector: 'app-paginator',
+	standalone: true,
+})
+class Paginator {
+	// Convert string to number
+	pageSize = injectAttribute('pageSize', 10, {
+		transform: numberAttribute,
+	});
+
+	// Convert string to boolean
+	disabled = injectAttribute('disabled', false, {
+		transform: booleanAttribute,
+	});
+}
+```
+
+```html
+<app-paginator pageSize="20" disabled />
+```

--- a/libs/ngxtension/inject-attribute/README.md
+++ b/libs/ngxtension/inject-attribute/README.md
@@ -1,0 +1,3 @@
+# ngxtension/inject-attribute
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/inject-attribute`.

--- a/libs/ngxtension/inject-attribute/ng-package.json
+++ b/libs/ngxtension/inject-attribute/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/inject-attribute/project.json
+++ b/libs/ngxtension/inject-attribute/project.json
@@ -1,0 +1,20 @@
+{
+	"name": "ngxtension/inject-attribute",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/inject-attribute/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["inject-attribute"]
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/inject-attribute/src/index.ts
+++ b/libs/ngxtension/inject-attribute/src/index.ts
@@ -1,0 +1,1 @@
+export * from './inject-attribute';

--- a/libs/ngxtension/inject-attribute/src/inject-attribute.spec.ts
+++ b/libs/ngxtension/inject-attribute/src/inject-attribute.spec.ts
@@ -1,0 +1,159 @@
+import { Component, Injector, inject } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { injectAttribute } from './inject-attribute';
+
+describe(injectAttribute.name, () => {
+	describe('with default value', () => {
+		it('should return default value when attribute is not present', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				variation = injectAttribute<string>('variation', 'ngx-default');
+			}
+
+			const fixture = TestBed.createComponent(TestComponent);
+			fixture.detectChanges();
+
+			expect(fixture.componentInstance.variation).toBe('ngx-default');
+		});
+
+		it('should work with different default values', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				stringAttr = injectAttribute<string>('string-attr', 'ngx-default');
+				numberAttr = injectAttribute<number>('number-attr', 0);
+			}
+
+			const fixture = TestBed.createComponent(TestComponent);
+			fixture.detectChanges();
+
+			expect(fixture.componentInstance.stringAttr).toBe('ngx-default');
+			expect(fixture.componentInstance.numberAttr).toBe(0);
+		});
+
+		it('should return default value when transform is provided but attribute is missing', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				count = injectAttribute<number>('count', 42, {
+					transform: (value) => Number(value),
+				});
+				disabled = injectAttribute('disabled', true, {
+					transform: (value) => value === '' || value === 'true',
+				});
+			}
+
+			const fixture = TestBed.createComponent(TestComponent);
+			fixture.detectChanges();
+
+			expect(fixture.componentInstance.count).toBe(42);
+			expect(fixture.componentInstance.disabled).toBe(true);
+		});
+	});
+
+	describe('with custom injector', () => {
+		it('should use custom injector when provided', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				private customInjector = inject(Injector);
+				variation = injectAttribute<string>('variation', 'primary', {
+					injector: this.customInjector,
+				});
+			}
+
+			const fixture = TestBed.createComponent(TestComponent);
+			fixture.detectChanges();
+
+			expect(fixture.componentInstance.variation).toBe('primary');
+		});
+	});
+
+	describe('injectAttribute.required', () => {
+		it('should throw error when attribute is not present', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				variation = injectAttribute.required<string>('variation');
+			}
+
+			expect(() => {
+				TestBed.createComponent(TestComponent);
+			}).toThrow();
+		});
+
+		it('should return attribute value when present', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				variation = injectAttribute.required<string>('variation');
+			}
+
+			@Component({
+				selector: 'wrapper',
+				standalone: true,
+				imports: [TestComponent],
+				template: '<test-component variation="primary" />',
+			})
+			class WrapperComponent {}
+
+			const fixture = TestBed.createComponent(WrapperComponent);
+			fixture.detectChanges();
+
+			const testComponent = fixture.debugElement.query(
+				(el) => el.name === 'test-component',
+			).componentInstance as TestComponent;
+
+			expect(testComponent.variation).toBe('primary');
+		});
+
+		it('should use transform function for type coercion', () => {
+			@Component({
+				selector: 'test-component',
+				standalone: true,
+				template: '',
+			})
+			class TestComponent {
+				maxlength = injectAttribute.required<number>('maxlength', {
+					transform: (value) => Number(value),
+				});
+			}
+
+			@Component({
+				selector: 'wrapper',
+				standalone: true,
+				imports: [TestComponent],
+				template: '<test-component maxlength="100" />',
+			})
+			class WrapperComponent {}
+
+			const fixture = TestBed.createComponent(WrapperComponent);
+			fixture.detectChanges();
+
+			const testComponent = fixture.debugElement.query(
+				(el) => el.name === 'test-component',
+			).componentInstance as TestComponent;
+
+			expect(testComponent.maxlength).toBe(100);
+		});
+	});
+});

--- a/libs/ngxtension/inject-attribute/src/inject-attribute.ts
+++ b/libs/ngxtension/inject-attribute/src/inject-attribute.ts
@@ -1,0 +1,81 @@
+import { HostAttributeToken, inject, type Injector } from '@angular/core';
+import { assertInjector } from 'ngxtension/assert-injector';
+
+/**
+ * Options for the `injectAttribute` function.
+ */
+export type InjectAttributeOptions<T = unknown> = {
+	/**
+	 * Custom injector to use for dependency injection.
+	 */
+	injector?: Injector;
+	/**
+	 * Transform function to convert the string attribute value to the desired type.
+	 * This is useful for type coercion (e.g., string to number or boolean).
+	 */
+	transform?: (value: string) => T;
+};
+
+//INSPIRED BY @netbasal ARTICLE https://medium.com/netanelbasal/streamlining-attribute-injection-in-angular-the-hostattributetoken-approach-494f5c1428b8
+
+/**
+ * Injects the value of a host attribute with a default value if the attribute is not present.
+ * This is a simplified wrapper around Angular's `HostAttributeToken`
+ *
+ * @template T - The type of the attribute value
+ * @param {string} key - The name of the attribute to inject
+ * @param {T} defaultValue - The default value to return if the attribute is not present
+ * @param {InjectAttributeOptions} options - Optional configuration for the injector
+ * @returns {T} The attribute value or the default value
+ *
+ * @example
+ * ```ts
+ * export class Button {
+ *   variation = injectAttribute<'primary' | 'secondary'>('variation', 'primary');
+ * }
+ * ```
+ *
+ * @example
+ * <app-button variation="secondary" />
+ */
+export function injectAttribute<T>(
+	key: string,
+	defaultValue: T,
+	options?: InjectAttributeOptions<T>,
+): T {
+	return assertInjector(injectAttribute, options?.injector, () => {
+		const value = inject(new HostAttributeToken(key), { optional: true });
+
+		if (value == null) {
+			return defaultValue;
+		}
+
+		if (options?.transform) {
+			return options.transform(value);
+		}
+
+		return value as T;
+	});
+}
+
+/**
+ * Injects the value of a host attribute that must be present.
+ * Throws an error if the attribute is not provided.
+ *
+ * @template T - The type of the attribute value
+ * @param {string} key - The name of the attribute to inject
+ * @param {InjectAttributeOptions} options - Optional configuration for the injector
+ * @returns {T} The attribute value
+ * @throws {Error} If the attribute is not present in the host element
+ */
+export namespace injectAttribute {
+	export function required<T>(
+		key: string,
+		options?: InjectAttributeOptions<T>,
+	): T {
+		return assertInjector(required, options?.injector, () => {
+			const value = inject(new HostAttributeToken(key));
+			return options?.transform ? options.transform(value) : (value as T);
+		});
+	}
+}


### PR DESCRIPTION
Built on top of `HostAttributeToken`, this helper provides a clean, function-based way to read **static host attributes** through `inject()`.  
 