### PR TITLE
fix: allow host binding migration to work with empty decorator

### DIFF
--- a/libs/plugin/src/generators/convert-host-binding/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-host-binding/__snapshots__/generator.spec.ts.snap
@@ -114,3 +114,16 @@ exports[`convert-host-binding generator should convert properly for directive 1`
   }
   "
 `;
+
+exports[`convert-host-binding generator should not crash for abstract directive 1`] = `
+"
+  import { Directive } from '@angular/core';
+
+    @Directive({
+        host: { '[attr.active]': 'active' }
+    })
+    export abstract class MyDirective {
+      readonly active = true;
+    }
+  "
+`;

--- a/libs/plugin/src/generators/convert-host-binding/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-host-binding/generator.spec.ts
@@ -96,6 +96,14 @@ const filesMap = {
       }
     }
   `,
+	abstractDirective: `
+  import { Directive, HostBinding } from '@angular/core';
+
+    @Directive()
+    export abstract class MyDirective {
+      @HostBinding('attr.active') readonly active = true;
+    }
+  `,
 };
 
 describe('convert-host-binding generator', () => {
@@ -163,6 +171,14 @@ describe('convert-host-binding generator', () => {
 
 	it('should convert properly for component with duplicate host binding', async () => {
 		const readContent = setup('componentWithDuplicateHostBinding');
+		await convertHostBindingGenerator(tree, options);
+
+		const [updated] = readContent();
+		expect(updated).toMatchSnapshot();
+	});
+
+	it('should not crash for abstract directive', async () => {
+		const readContent = setup('abstractDirective');
 		await convertHostBindingGenerator(tree, options);
 
 		const [updated] = readContent();

--- a/libs/plugin/src/generators/convert-host-binding/generator.ts
+++ b/libs/plugin/src/generators/convert-host-binding/generator.ts
@@ -188,7 +188,7 @@ const addHostProperty = (sourceFile) => {
 
 		const resolveHostProperties = (hostProperties) => {
 			if (Object.keys(hostProperties).length > 0) {
-				const hostProperty = decorator.getArguments()[0].getProperty('host');
+				const hostProperty = decorator.getArguments()[0]?.getProperty('host');
 				if (hostProperty) {
 					const existingHostBindings = hostProperty.getInitializerIfKindOrThrow(
 						SyntaxKind.ObjectLiteralExpression,
@@ -200,6 +200,12 @@ const addHostProperty = (sourceFile) => {
 						});
 					});
 				} else {
+					if (!decorator.getArguments().length) {
+						// Abstract directive might not have any arguments
+						// Adding empty object literal will prevent crash
+						decorator.addArgument('{}');
+					}
+
 					decorator.getArguments()[0].addPropertyAssignment({
 						name: 'host',
 						initializer: `{ ${Object.entries(hostProperties)


### PR DESCRIPTION
Closes #642 

When `decorator.getArguments()` returns `[]` add empty object to prevent crash when calling `decorator.getArguments()[0].addPropertyAssignment(...)`.

If there is a better solution let me know and I can fix it