### PR TITLE
[ci] exclude .git and .gitignore during docs rsync

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -56,7 +56,7 @@ jobs:
           mkdir -p /tmp/astro-docs
 
           # Copy built docs to temp directory
-          rsync -av --delete --exclude 'node_modules' docs/dist/ /tmp/astro-docs/
+          rsync -av --delete --exclude 'node_modules' --exclude '.git' --exclude '.gitignore' /tmp/astro-docs/ .
 
           echo "node_modules" > .gitignore
           echo "docs/node_modules/" >> .gitignore
@@ -71,7 +71,7 @@ jobs:
           fi
 
           # Copy docs from temp directory to current branch
-          rsync -av --delete --exclude 'node_modules' /tmp/astro-docs/ .
+          rsync -av --delete --exclude 'node_modules' --exclude '.git' --exclude '.gitignore' /tmp/astro-docs/ .
 
           rm -rf node_modules
           rm -rf docs/node_modules


### PR DESCRIPTION
@eneajaho the first attemt was probably to eager. it deleted the git folders as well:

```ts
fatal: not a git repository (or any of the parent directories): .git
Error: Process completed with exit code 128.
```
https://github.com/ngxtension/ngxtension-platform/actions/runs/22437540174/job/64971169187