### PR TITLE
feat: add reactive helper `on`

### DIFF
--- a/docs/src/content/docs/utilities/Signals/on.md
+++ b/docs/src/content/docs/utilities/Signals/on.md
@@ -1,0 +1,100 @@
+---
+title: on
+description: ngxtension/reactive-on
+entryPoint: ngxtension/reactive-on
+badge: new
+contributors: ['jeanmeche']
+---
+
+`on` is a helper function that allows you to create an effect with explicit dependencies. It is designed to be used directly inside `effect()`.
+
+It is similar to `explicitEffect`, but intended for inline usage within `effect()`.
+
+## Usage
+
+`on` accepts dependencies (a signal, an array of signals, or a record of signals) and a callback function. The callback is executed only when the dependencies change.
+
+### Basic Usage
+
+```ts
+import { effect, signal } from '@angular/core';
+import { on } from 'ngxtension/reactive-on';
+
+const count = signal(0);
+const doubleJson = signal(0);
+
+effect(
+	on([count, doubleJson], ([c, d]) => {
+		console.log(`Count: ${c}, Double: ${d}`);
+	}),
+);
+```
+
+This is equivalent to:
+
+```ts
+effect(() => {
+	const c = count();
+	const d = doubleJson();
+	untracked(() => {
+		console.log(`Count: ${c}, Double: ${d}`);
+	});
+});
+```
+
+### Accessing Previous Values
+
+The callback provides access to:
+
+1. The current input values (dependencies).
+2. The previous input values.
+3. The returned value from the previous execution of the callback.
+
+```ts
+const count = signal(1);
+
+effect(
+	on(count, (currentCount, prevCount, prevResult) => {
+		console.log(`Current: ${currentCount}`);
+		console.log(`Previous Input: ${prevCount}`);
+		console.log(`Previous Result: ${prevResult}`);
+
+		// This value will be available as `prevResult` in the next run
+		return `Count is ${currentCount}`;
+	}),
+);
+```
+
+### Defer Execution
+
+You can defer the initial execution of the effect using the `defer` option.
+
+```ts
+effect(
+	on(
+		count,
+		(value) => {
+			console.log(`Value changed: ${value}`);
+		},
+		{ defer: true },
+	),
+);
+```
+
+### Cleanup Function
+
+The callback receives a cleanup function registration callback as the last argument.
+
+```ts
+effect(
+	on(count, (value, prev, prevVal, cleanup) => {
+		const timer = setInterval(() => {
+			console.log(value);
+		}, 1000);
+
+		cleanup(() => {
+			clearInterval(timer);
+		});
+	}),
+);
+```

--- a/libs/ngxtension/reactive-on/README.md
+++ b/libs/ngxtension/reactive-on/README.md
@@ -1,0 +1,3 @@
+# ngxtension/reactive-on
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/reactive-on`.

--- a/libs/ngxtension/reactive-on/ng-package.json
+++ b/libs/ngxtension/reactive-on/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/reactive-on/project.json
+++ b/libs/ngxtension/reactive-on/project.json
@@ -1,0 +1,20 @@
+{
+	"name": "ngxtension/reactive-on",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/reactive-on/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["reactive-on"]
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/reactive-on/src/index.ts
+++ b/libs/ngxtension/reactive-on/src/index.ts
@@ -1,0 +1,1 @@
+export * from './on';

--- a/libs/ngxtension/reactive-on/src/on.spec.ts
+++ b/libs/ngxtension/reactive-on/src/on.spec.ts
@@ -1,0 +1,231 @@
+import {
+	ApplicationRef,
+	Injector,
+	computed,
+	effect,
+	signal,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { on } from './on';
+
+describe(on.name, () => {
+	let injector: Injector;
+	let appRef: ApplicationRef;
+
+	beforeEach(() => {
+		injector = TestBed.inject(Injector);
+		appRef = TestBed.inject(ApplicationRef);
+	});
+
+	it('should run effect when dependency changes (single)', () => {
+		const count = signal(0);
+		const log: number[] = [];
+
+		effect(
+			on(count, (c) => {
+				log.push(c);
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([0]);
+
+		count.set(1);
+		appRef.tick();
+		expect(log).toEqual([0, 1]);
+	});
+
+	it('should not run effect when untracked dependency changes', () => {
+		const count = signal(0);
+		const other = signal(10);
+		const log: number[] = [];
+
+		effect(
+			on(count, (c) => {
+				// accessing 'other' which is not in deps
+				log.push(c + other());
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([10]);
+
+		other.set(20);
+		appRef.tick();
+		// Should NOT run again because 'other' is not in deps list passed to on()
+		expect(log).toEqual([10]);
+
+		count.set(1);
+		appRef.tick();
+		// Should run now, seeing the new value of 'other' ONLY because 'count' changed
+		expect(log).toEqual([10, 21]);
+	});
+
+	it('should run effect with multiple dependencies (array)', () => {
+		const a = signal(1);
+		const b = signal(2);
+		const log: number[] = [];
+
+		effect(
+			on([a, b], ([valA, valB]) => {
+				log.push(valA + valB);
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([3]);
+
+		a.set(2);
+		appRef.tick();
+		expect(log).toEqual([3, 4]);
+
+		b.set(3);
+		appRef.tick();
+		expect(log).toEqual([3, 4, 5]);
+	});
+
+	it('should pass object with signals as input', () => {
+		const a = signal(1);
+		const b = signal(2);
+		const log: number[] = [];
+
+		effect(
+			on({ a, b }, ({ a: valA, b: valB }) => {
+				log.push(valA * valB);
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([2]);
+
+		a.set(3);
+		appRef.tick();
+		expect(log).toEqual([2, 6]);
+
+		b.set(4);
+		appRef.tick();
+		expect(log).toEqual([2, 6, 12]);
+	});
+
+	it('should pass previous input correctly', () => {
+		const count = signal(0);
+		const log: string[] = [];
+
+		effect(
+			on(count, (input, prevInput) => {
+				const result = `cur: ${input}, prevIn: ${prevInput}`;
+				log.push(result);
+				return undefined;
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual(['cur: 0, prevIn: undefined']);
+
+		count.set(1);
+		appRef.tick();
+		expect(log).toEqual(['cur: 0, prevIn: undefined', 'cur: 1, prevIn: 0']);
+	});
+
+	it('should support cleanup function', () => {
+		const count = signal(0);
+		const log: string[] = [];
+
+		const effectRef = effect(
+			on(count, (c, _, __, onCleanup) => {
+				log.push(`run: ${c}`);
+				onCleanup(() => {
+					log.push(`cleanup: ${c}`);
+				});
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual(['run: 0']);
+
+		count.set(1);
+		appRef.tick();
+		expect(log).toEqual(['run: 0', 'cleanup: 0', 'run: 1']);
+
+		effectRef.destroy();
+		expect(log).toEqual(['run: 0', 'cleanup: 0', 'run: 1', 'cleanup: 1']);
+	});
+
+	it('should pass previous value correctly', () => {
+		const count = signal(1);
+		const log: number[] = [];
+
+		effect(
+			on(count, (c, _, prevValue) => {
+				const result = c + ((prevValue as number) || 0);
+				log.push(result);
+				return result;
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([1]); // 1 + 0 (undefined prevValue treated as 0)
+
+		count.set(2);
+		appRef.tick();
+		expect(log).toEqual([1, 3]); // 2 + 1 (prevValue was 1)
+
+		count.set(3);
+		appRef.tick();
+		expect(log).toEqual([1, 3, 6]); // 3 + 3 (prevValue was 3)
+	});
+
+	it('should work with computed signals', () => {
+		const count = signal(1);
+		const doubleCount = computed(() => count() * 2);
+		const log: number[] = [];
+
+		effect(
+			on(doubleCount, (val) => {
+				log.push(val);
+			}),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([2]);
+
+		count.set(2);
+		appRef.tick();
+		expect(log).toEqual([2, 4]);
+	});
+
+	it('should not run if defer is true and dependencies did not change', () => {
+		const count = signal(0);
+		const log: number[] = [];
+
+		effect(
+			on(
+				count,
+				(c) => {
+					log.push(c);
+				},
+				{ defer: true },
+			),
+			{ injector },
+		);
+
+		appRef.tick();
+		expect(log).toEqual([]); // Should not run on initial tick due to defer
+
+		count.set(1);
+		appRef.tick();
+		expect(log).toEqual([1]); // Should run now because count changed
+
+		count.set(1);
+		appRef.tick();
+		expect(log).toEqual([1]); // Should NOT run again because count did not change
+	});
+});

--- a/libs/ngxtension/reactive-on/src/on.ts
+++ b/libs/ngxtension/reactive-on/src/on.ts
@@ -1,0 +1,122 @@
+import { EffectCleanupRegisterFn, Signal, untracked } from '@angular/core';
+
+export type Accessor<T> = Signal<T> | (() => T);
+
+/**
+ * Makes dependencies of a computation explicit
+
+ * @param deps list of reactive dependencies or a single reactive dependency
+ * @param fn computation on input; the current previous content(s) of input and the previous value are given as arguments and it returns a new value
+ * @returns an effect function that is passed into `effect`. For example:
+ *
+ * ```typescript
+ * effect(on(a, (v) => console.log(v, b())));
+ *
+ * // is equivalent to:
+ * effect(() => {
+ *   const v = a();
+ *   untracked(() => console.log(v, b()));
+ * });
+ * ```
+ */
+export function on<
+	const Deps extends readonly Accessor<unknown>[],
+	U,
+	V = U | undefined,
+>(
+	deps: readonly [...Deps],
+	fn: (
+		input: {
+			-readonly [K in keyof Deps]: Deps[K] extends Accessor<infer T>
+				? T
+				: never;
+		},
+		prevInput:
+			| {
+					-readonly [K in keyof Deps]: Deps[K] extends Accessor<infer T>
+						? T
+						: never;
+			  }
+			| undefined,
+		prevValue: V | undefined,
+		cleanupFn: EffectCleanupRegisterFn,
+	) => U,
+	options?: { defer?: boolean },
+): (onCleanup: EffectCleanupRegisterFn) => void;
+
+export function on<
+	const Deps extends Record<string, Accessor<unknown>>,
+	U,
+	V = U | undefined,
+>(
+	deps: Deps,
+	fn: (
+		input: { [K in keyof Deps]: Deps[K] extends Accessor<infer T> ? T : never },
+		prevInput:
+			| { [K in keyof Deps]: Deps[K] extends Accessor<infer T> ? T : never }
+			| undefined,
+		prevValue: V | undefined,
+		cleanupFn: EffectCleanupRegisterFn,
+	) => U,
+	options?: { defer?: boolean },
+): (onCleanup: EffectCleanupRegisterFn) => void;
+
+export function on<S, U, V = U | undefined>(
+	deps: Accessor<S>,
+	fn: (
+		input: S,
+		prevInput: S | undefined,
+		prevValue: V | undefined,
+		cleanupFn: EffectCleanupRegisterFn,
+	) => U,
+	options?: { defer?: boolean },
+): (onCleanup: EffectCleanupRegisterFn) => void;
+
+export function on(
+	deps:
+		| Accessor<unknown>
+		| readonly Accessor<unknown>[]
+		| Record<string, Accessor<unknown>>,
+	fn: (
+		input: any,
+		prevInput: any,
+		prevValue: any,
+		cleanupFn: EffectCleanupRegisterFn,
+	) => any,
+	options?: { defer?: boolean },
+): (onCleanup: EffectCleanupRegisterFn) => void {
+	const isArray = Array.isArray(deps);
+	const isAccessor = typeof deps === 'function';
+	let prevInput: unknown;
+	let prevValue: unknown;
+	let defer = options && options.defer;
+
+	return (onCleanup: EffectCleanupRegisterFn) => {
+		let input: unknown;
+
+		if (isArray) {
+			input = (deps as readonly Accessor<unknown>[]).map((d) => d());
+		} else if (isAccessor) {
+			input = (deps as Accessor<unknown>)();
+		} else {
+			// Object
+			input = Object.keys(deps).reduce(
+				(acc, key) => {
+					acc[key] = (deps as Record<string, Accessor<unknown>>)[key]();
+					return acc;
+				},
+				{} as Record<string, unknown>,
+			);
+		}
+
+		if (defer) {
+			defer = false;
+			return;
+		}
+
+		untracked(() => {
+			prevValue = fn(input, prevInput, prevValue, onCleanup);
+			prevInput = input;
+		});
+	};
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -135,6 +135,7 @@
 			"ngxtension/not-pattern": ["libs/ngxtension/not-pattern/src/index.ts"],
 			"ngxtension/on-event": ["libs/ngxtension/on-event/src/index.ts"],
 			"ngxtension/poll": ["libs/ngxtension/poll/src/index.ts"],
+			"ngxtension/reactive-on": ["libs/ngxtension/reactive-on/src/index.ts"],
 			"ngxtension/repeat": ["libs/ngxtension/repeat/src/index.ts"],
 			"ngxtension/repeat-pipe": ["libs/ngxtension/repeat-pipe/src/index.ts"],
 			"ngxtension/resize": ["libs/ngxtension/resize/src/index.ts"],


### PR DESCRIPTION
An alternative to `explicitEffect` for explicit dependencies in an effect