### PR TITLE
fix(inject-is-intersecting): Fix encapsulation, SSR safety, and shared-element subscription teardown

### DIFF
--- a/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.spec.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.spec.ts
@@ -106,6 +106,72 @@ describe(injectIsIntersecting.name, () => {
 	});
 });
 
+describe(IsInViewportService.name, () => {
+	let service: IsInViewportService;
+	let observeSpy: jest.Mock;
+	let unobserveSpy: jest.Mock;
+	let disconnectSpy: jest.Mock;
+	let originalIntersectionObserver: any;
+
+	beforeEach(() => {
+		// Setup spies for the native IntersectionObserver
+		observeSpy = jest.fn();
+		unobserveSpy = jest.fn();
+		disconnectSpy = jest.fn();
+
+		// Mock the global IntersectionObserver
+		originalIntersectionObserver = window.IntersectionObserver;
+		window.IntersectionObserver = jest.fn().mockImplementation(() => ({
+			observe: observeSpy,
+			unobserve: unobserveSpy,
+			disconnect: disconnectSpy,
+		})) as any;
+
+		TestBed.configureTestingModule({
+			providers: [IsInViewportService],
+		});
+
+		service = TestBed.inject(IsInViewportService);
+	});
+
+	afterEach(() => {
+		// Restore the original IntersectionObserver to avoid leaking into other tests
+		window.IntersectionObserver = originalIntersectionObserver;
+	});
+
+	it('should track refcounts and only unobserve/disconnect when the count reaches zero', () => {
+		const el = document.createElement('div');
+
+		// 1. First consumer starts observing
+		service.observe(el);
+		expect(observeSpy).toHaveBeenCalledWith(el);
+		expect(observeSpy).toHaveBeenCalledTimes(1);
+
+		// 2. Second consumer starts observing the SAME element
+		service.observe(el);
+
+		// The native observe method should NOT be called a second time
+		expect(observeSpy).toHaveBeenCalledTimes(1);
+
+		// 3. First consumer stops observing
+		service.unobserve(el);
+
+		// Because the second consumer is still observing, it should bail early
+		expect(unobserveSpy).not.toHaveBeenCalled();
+		expect(disconnectSpy).not.toHaveBeenCalled();
+
+		// 4. Second consumer stops observing
+		service.unobserve(el);
+
+		// Now that the refcount is 0, it should fully unobserve the element
+		expect(unobserveSpy).toHaveBeenCalledWith(el);
+		expect(unobserveSpy).toHaveBeenCalledTimes(1);
+
+		// Since this was the last observed element in the entire service, it should disconnect
+		expect(disconnectSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
 class MockIsInViewportService implements IsInViewportServiceInterface {
 	elMap = new Map<Element, Subject<IntersectionObserverEntry>>();
 

--- a/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.spec.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.spec.ts
@@ -42,7 +42,7 @@ describe(injectIsIntersecting.name, () => {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
 			const entry: IntersectionObserverEntry = { isIntersecting: true };
-			isInViewportService.intersect(fixture.nativeElement, entry);
+			(isInViewportService as any).intersect(fixture.nativeElement, entry);
 		});
 	});
 
@@ -99,7 +99,7 @@ describe(injectIsIntersecting.name, () => {
 				target: component.divEl,
 				// target: document.createElement('div') --> uncomment this to fail the test
 			};
-			isInViewportService.intersect(component.divEl, entry);
+			(isInViewportService as any).intersect(component.divEl, entry);
 
 			expect(component.intersected).toBe(true);
 		});

--- a/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/inject-is-intersecting.ts
@@ -1,6 +1,6 @@
 import { DestroyRef, ElementRef, inject, Injector } from '@angular/core';
 import { assertInjector } from 'ngxtension/assert-injector';
-import { injectDestroy } from 'ngxtension/inject-destroy';
+import { Observable } from 'rxjs';
 import { IsInViewportService } from './is-in-viewport.service';
 
 export interface InjectIsIntersectingOptions {
@@ -39,18 +39,16 @@ export interface InjectIsIntersectingOptions {
 export const injectIsIntersecting = ({
 	injector,
 	element,
-}: InjectIsIntersectingOptions = {}) => {
-	return assertInjector(injectDestroy, injector, () => {
-		const el = element ?? inject(ElementRef).nativeElement;
-		const inInViewportService = inject(IsInViewportService);
+}: InjectIsIntersectingOptions = {}): Observable<IntersectionObserverEntry> => {
+	return assertInjector(injectIsIntersecting, injector, () => {
+		const el = element ?? inject(ElementRef<Element>).nativeElement;
+		const isInViewportService = inject(IsInViewportService);
 		const destroyRef = inject(DestroyRef);
 
-		const sub = inInViewportService.observe(el);
+		const obs$ = isInViewportService.observe(el);
 
-		destroyRef.onDestroy(() => {
-			inInViewportService.unobserve(el);
-		});
+		destroyRef.onDestroy(() => isInViewportService.unobserve(el));
 
-		return sub;
+		return obs$;
 	});
 };

--- a/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
@@ -1,16 +1,18 @@
 import { inject, Injectable, NgZone } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class IsInViewportService implements IsInViewportServiceInterface {
-	private ngZone = inject(NgZone);
+	private readonly ngZone = inject(NgZone);
 
-	#observerListeners = new Map<Element, Subject<IntersectionObserverEntry>>();
+	private observerListeners = new Map<
+		Element,
+		Subject<IntersectionObserverEntry>
+	>();
+	private observer?: IntersectionObserver;
 
-	#observer?: IntersectionObserver;
-
-	#createObserver() {
-		this.#observer = this.ngZone.runOutsideAngular(() => {
+	private createObserver() {
+		this.observer = this.ngZone.runOutsideAngular(() => {
 			return new IntersectionObserver((entries) => {
 				for (const entry of entries) {
 					this.intersect(entry.target, entry);
@@ -19,51 +21,49 @@ export class IsInViewportService implements IsInViewportServiceInterface {
 		});
 	}
 
-	observe(element: Element) {
-		if (!this.#observer) {
-			this.#createObserver();
+	observe(element: Element): Observable<IntersectionObserverEntry> {
+		if (!this.observer) {
+			this.createObserver();
 		}
 
-		if (this.#observerListeners.has(element)) {
-			return this.#observerListeners.get(element)!;
+		if (this.observerListeners.has(element)) {
+			return this.observerListeners.get(element)!.asObservable();
 		}
 
-		this.#observerListeners.set(
+		this.observerListeners.set(
 			element,
 			new Subject<IntersectionObserverEntry>(),
 		);
-		this.#observer?.observe(element);
+		this.observer?.observe(element);
 
-		return this.#observerListeners.get(element)!;
+		return this.observerListeners.get(element)!.asObservable();
 	}
 
-	unobserve(element: Element) {
-		this.#observer?.unobserve(element);
+	unobserve(element: Element): void {
+		this.observer?.unobserve(element);
 
-		this.#observerListeners.get(element)?.complete();
-		this.#observerListeners.delete(element);
+		this.observerListeners.get(element)?.complete();
+		this.observerListeners.delete(element);
 
-		if (this.#observerListeners.size === 0) {
-			this.#disconnect();
+		if (this.observerListeners.size === 0) {
+			this.disconnect();
 		}
 	}
 
-	intersect(element: Element, entry: IntersectionObserverEntry) {
-		const subject = this.#observerListeners.get(element);
-		// only emit if the subject is subscribed to
+	private intersect(element: Element, entry: IntersectionObserverEntry): void {
+		const subject = this.observerListeners.get(element);
 		if (subject?.observed) {
 			this.ngZone.run(() => subject.next(entry));
 		}
 	}
 
-	#disconnect() {
-		this.#observer?.disconnect();
-		this.#observer = undefined;
+	private disconnect(): void {
+		this.observer?.disconnect();
+		this.observer = undefined;
 	}
 }
 
 export interface IsInViewportServiceInterface {
-	observe(element: Element): Subject<IntersectionObserverEntry>;
+	observe(element: Element): Observable<IntersectionObserverEntry>;
 	unobserve(element: Element): void;
-	intersect(element: Element, entry: IntersectionObserverEntry): void;
 }

--- a/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
@@ -11,6 +11,7 @@ export class IsInViewportService implements IsInViewportServiceInterface {
 		Element,
 		Subject<IntersectionObserverEntry>
 	>();
+	private observerCounts = new Map<Element, number>(); // ref count per element
 	private observer?: IntersectionObserver;
 
 	private createObserver() {
@@ -29,6 +30,12 @@ export class IsInViewportService implements IsInViewportServiceInterface {
 			this.createObserver();
 		}
 
+		// Increment ref count regardless of whether the element is already observed
+		this.observerCounts.set(
+			element,
+			(this.observerCounts.get(element) ?? 0) + 1,
+		);
+
 		if (this.observerListeners.has(element)) {
 			return this.observerListeners.get(element)!.asObservable();
 		}
@@ -43,6 +50,16 @@ export class IsInViewportService implements IsInViewportServiceInterface {
 	}
 
 	unobserve(element: Element): void {
+		const count = (this.observerCounts.get(element) ?? 1) - 1;
+
+		if (count > 0) {
+			// Other consumers are still alive — just decrement and bail
+			this.observerCounts.set(element, count);
+			return;
+		}
+
+		// Last consumer gone — fully tear down this element
+		this.observerCounts.delete(element);
 		this.observer?.unobserve(element);
 
 		this.observerListeners.get(element)?.complete();

--- a/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
@@ -1,9 +1,11 @@
-import { inject, Injectable, NgZone } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class IsInViewportService implements IsInViewportServiceInterface {
 	private readonly ngZone = inject(NgZone);
+	private readonly platformId = inject(PLATFORM_ID);
 
 	private observerListeners = new Map<
 		Element,
@@ -12,6 +14,7 @@ export class IsInViewportService implements IsInViewportServiceInterface {
 	private observer?: IntersectionObserver;
 
 	private createObserver() {
+		if (!isPlatformBrowser(this.platformId)) return; // IntersectionObserver is not available on the server
 		this.observer = this.ngZone.runOutsideAngular(() => {
 			return new IntersectionObserver((entries) => {
 				for (const entry of entries) {

--- a/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
+++ b/libs/ngxtension/inject-is-intersecting/src/is-in-viewport.service.ts
@@ -50,7 +50,11 @@ export class IsInViewportService implements IsInViewportServiceInterface {
 	}
 
 	unobserve(element: Element): void {
-		const count = (this.observerCounts.get(element) ?? 1) - 1;
+		if (!this.observerCounts.has(element)) {
+			return;
+		}
+
+		const count = this.observerCounts.get(element)! - 1;
 
 		if (count > 0) {
 			// Other consumers are still alive — just decrement and bail


### PR DESCRIPTION
1. observe() now returns Observable<IntersectionObserverEntry> instead of exposing the internal Subject directly, preventing consumers from calling .next(), .error(), or .complete() externally
2. intersect() removed from the public interface and made private — it is an internal callback and should not be callable from outside the service
3. Added isPlatformBrowser() guard in createObserver() to prevent a ReferenceError crash in SSR environments where IntersectionObserver is unavailable
4. Added ref-counting via observerCounts so that when multiple components observe the same element, a single component being destroyed no longer completes the shared Subject and silently cuts off all other consumers
5. Fixed incorrect first argument to assertInjector (injectDestroy → injectIsIntersecting) so injection context errors report the correct origin