### PR TITLE
  fix(inject-query-params): treat valueless query params as empty string, not missing                                                                                                                  

### DIFF
--- a/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
@@ -222,6 +222,36 @@ describe(injectQueryParams.name, () => {
 		);
 		expect(instance.requiredId()).toBe('123');
 	});
+
+	it('returns an empty string for a query parameter with no value instead of the default/missing fallback', async () => {
+		const harness = await RouterTestingHarness.create();
+		const instance = await harness.navigateByUrl(
+			'/search?query',
+			SearchComponent,
+		);
+
+		expect(instance.queryParams()).toEqual({ query: '' });
+		expect(instance.searchParam()).toEqual('');
+		expect(instance.searchParamDefault()).toEqual('');
+	});
+
+	it('should not throw error when required query param has no value', async () => {
+		TestBed.configureTestingModule({
+			providers: [
+				provideRouter([
+					{ path: 'required', component: RequiredQueryParamComponent },
+				]),
+			],
+		});
+
+		const harness = await RouterTestingHarness.create();
+
+		const instance = await harness.navigateByUrl(
+			'/required?id',
+			RequiredQueryParamComponent,
+		);
+		expect(instance.requiredId()).toBe('');
+	});
 });
 
 describe(injectQueryParams.array.name, () => {
@@ -427,5 +457,35 @@ describe(injectQueryParams.array.name, () => {
 			RequiredArrayQueryParamComponent,
 		);
 		expect(instance.requiredIdArray()).toEqual(['123', '456']);
+	});
+
+	it('returns an array with an empty string for a query parameter with no value instead of the default/missing fallback', async () => {
+		const harness = await RouterTestingHarness.create();
+		const instance = await harness.navigateByUrl(
+			'/search?query',
+			SearchComponent,
+		);
+
+		expect(instance.queryParams()).toEqual({ query: '' });
+		expect(instance.searchParams()).toEqual(['']);
+		expect(instance.searchParamsDefault()).toEqual(['']);
+	});
+
+	it('should not throw error when required array query param has no value', async () => {
+		TestBed.configureTestingModule({
+			providers: [
+				provideRouter([
+					{ path: 'required', component: RequiredArrayQueryParamComponent },
+				]),
+			],
+		});
+
+		const harness = await RouterTestingHarness.create();
+
+		const instance = await harness.navigateByUrl(
+			'/required?id',
+			RequiredArrayQueryParamComponent,
+		);
+		expect(instance.requiredIdArray()).toEqual(['']);
 	});
 });

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
@@ -7,8 +7,9 @@ import {
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { provideRouter } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { injectQueryParams } from './inject-query-params';
 
 @Component({
@@ -251,6 +252,26 @@ describe(injectQueryParams.name, () => {
 			RequiredQueryParamComponent,
 		);
 		expect(instance.requiredId()).toBe('');
+	});
+
+	it('treats a null query parameter the same as a missing one', () => {
+		TestBed.configureTestingModule({
+			providers: [
+				{
+					provide: ActivatedRoute,
+					useValue: {
+						snapshot: { queryParams: { id: null } },
+						queryParams: of({ id: null }),
+					},
+				},
+			],
+		});
+
+		const idParam = TestBed.runInInjectionContext(() =>
+			injectQueryParams('id', { defaultValue: 'fallback' }),
+		);
+
+		expect(idParam()).toEqual('fallback');
 	});
 });
 

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.ts
@@ -143,7 +143,7 @@ export function injectQueryParams<ReadT>(
 				| string[]
 				| undefined;
 
-			if (!param) {
+			if (param === undefined) {
 				if (required) {
 					throw missingRequiredParamError(keyOrParamsTransform);
 				}
@@ -233,9 +233,9 @@ export namespace injectQueryParams {
 				options;
 
 			const transformParam = (
-				param: string | string[] | null,
+				param: string | string[] | null | undefined,
 			): (ReadT | string)[] | null => {
-				if (!param) {
+				if (param === undefined || param === null) {
 					if (required) {
 						throw missingRequiredParamError(key);
 					}

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.ts
@@ -141,9 +141,10 @@ export function injectQueryParams<ReadT>(
 			const param = params?.[keyOrParamsTransform] as
 				| string
 				| string[]
+				| null
 				| undefined;
 
-			if (param === undefined) {
+			if (param === undefined || param === null) {
 				if (required) {
 					throw missingRequiredParamError(keyOrParamsTransform);
 				}


### PR DESCRIPTION
                                                                                                                                                                                             
  ## Summary                                                                                                                                                                                           
  - `injectQueryParams('key')` used `if (!param)` to detect a missing param, but Angular's router parses a valueless query param (e.g. `?query`) as `''`, which is also falsy — so it was wrongly treated as missing, tripping the `required` error or falling back to `defaultValue`/`initialValue` instead of returning `''`.                                                                        
  - Fixed both the singular getter and `injectQueryParams.array`, which needs `param === undefined || param === null` rather than just `undefined`: its `transformParam` is typed to accept `string | string[] | null` (unlike the singular getter, which only ever sees `undefined` for a missing key), so dropping the `null` check would leave that branch unreachable for a `null` input.              
  - Added regression tests for both APIs, with and without `required: true`.                                                                                                                           
                                                                                                                                                                                                       
  Fixes #693 