### PR TITLE
fix(when-document-visible): improve visibility state check in partiti…

### DIFF
--- a/libs/ngxtension/when-document-visible/src/when-document-visible.ts
+++ b/libs/ngxtension/when-document-visible/src/when-document-visible.ts
@@ -24,9 +24,10 @@ export function whenDocumentVisible<T>(
 	options?: InjectDocumentVisibilityOptions,
 ): MonoTypeOperatorFunction<T> {
 	const visibilityChanged$ = injectDocumentVisibilityStream(options);
-	const [pageVisible$, pageHidden$] = partition(visibilityChanged$, () => {
-		return document.visibilityState === 'visible';
-	});
+	const [pageVisible$, pageHidden$] = partition(
+		visibilityChanged$,
+		(visibilityState) => visibilityState === 'visible',
+	);
 	return (source: Observable<T>) => {
 		return source.pipe(
 			takeUntil(pageHidden$),


### PR DESCRIPTION
when-document-visible:
partition() predicate reads the global document instead of the injected/overridable one the source stream actually provides. easy ssr fix
