### PR TITLE
feat(connect): enhance reducer behavior for falsy values in signal up…

### DIFF
--- a/libs/ngxtension/connect/src/connect.spec.ts
+++ b/libs/ngxtension/connect/src/connect.spec.ts
@@ -371,6 +371,42 @@ describe(connect.name, () => {
 		});
 	});
 
+	describe('reducer returning a falsy value', () => {
+		it('should use the reducer result instead of the raw emission when it is a falsy primitive', () => {
+			const isActive = signal(true);
+
+			TestBed.runInInjectionContext(() => {
+				connect(isActive, of('toggle'), () => false);
+			});
+
+			expect(isActive()).toBe(false);
+		});
+
+		it('should use a reducer result of 0 instead of falling back to the raw emission', () => {
+			const count = signal(5);
+
+			TestBed.runInInjectionContext(() => {
+				// reducer computes a delta which legitimately evaluates to 0
+				connect(count, of(5), (prev, next) => next - prev);
+			});
+
+			expect(count()).toBe(0);
+		});
+
+		it('should not silently replace object state with the raw emission when a reducer guard returns a falsy value', () => {
+			const state = signal({ age: 30 });
+
+			TestBed.runInInjectionContext(() => {
+				// reducer intentionally returns null to skip the update
+				connect(state, of({ age: 20 }), (prev, next) =>
+					next.age > prev.age ? { age: next.age } : (null as any),
+				);
+			});
+
+			expect(state()).toEqual({ age: 30 });
+		});
+	});
+
 	describe('connects an observable to a signal not in injection context using injector', () => {
 		@Component({ standalone: true, template: '' })
 		class TestComponent implements OnInit {

--- a/libs/ngxtension/connect/src/connect.ts
+++ b/libs/ngxtension/connect/src/connect.ts
@@ -120,7 +120,7 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 			const update = () => {
 				signal.update((prev) => {
 					if (!isObject(prev)) {
-						return reducer?.(prev, x) || x;
+						return reducer ? reducer(prev, x) : x;
 					}
 
 					if (!isObject(x)) {
@@ -131,7 +131,7 @@ export function connect(signal: WritableSignal<unknown>, ...args: any[]) {
 							: reducedValue;
 					}
 
-					const curr = reducer?.(prev, x) || x;
+					const curr = reducer ? reducer(prev, x) : x;
 
 					if (isDate(curr)) {
 						return new Date(curr);


### PR DESCRIPTION
`reducer?.(prev, x) || x` is meant to say "if a reducer was provided, use its result; otherwise use the raw emitted value x." But || only checks truthiness, not whether the reducer ran. 
So if the reducer is defined and legitimately computes a falsy value (`0, '', false, null, ect`) the || treats that as "nothing," discards it, and silently substitutes the raw x from the observable instead.                                                                                                                                                                                               
                                                