### PR TITLE
fix(inject-route-fragment): return default values even when falsy

### DIFF
--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
@@ -78,6 +78,14 @@ describe(injectRouteFragment.name, () => {
 		expect(instance.numberFragmentDefaultValue()).toEqual(100000000);
 	});
 
+	it('returns a falsy default value instead of falling back to null', async () => {
+		const instance = await harness.navigateByUrl('test', TestComponent);
+
+		// defaultValue: 0 is a legitimate falsy default and should be
+		// returned as-is when there is no fragment, not discarded for `null`
+		expect(instance.zeroFragmentDefaultValue()).toEqual(0);
+	});
+
 	it('returns right signals and values for different parsers', async () => {
 		const instance = await harness.navigateByUrl('test', TestComponent);
 
@@ -127,6 +135,7 @@ export class TestComponent implements OnInit {
 	fragmentDefaultValue = injectRouteFragment({
 		defaultValue: 'default-fragment',
 	});
+	zeroFragmentDefaultValue = injectRouteFragment({ defaultValue: 0 });
 	isFragmentAvailable = injectRouteFragment({
 		parse: (fragment) => !!fragment,
 	});

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
@@ -54,7 +54,7 @@ export function injectRouteFragment<T>(
 		const route = inject(ActivatedRoute);
 		const initialRouteFragment = route.snapshot.fragment;
 		const getFragment = (fragment: string | null) => {
-			if (fragment === null && options?.defaultValue) {
+			if (fragment === null && options?.defaultValue !== undefined) {
 				return options.defaultValue;
 			}
 			if (options?.parse) {


### PR DESCRIPTION
defaultValue used a truthy check, so falsy defaults (0, '', false) were silently discarded and `null` was returned instead.                                                                              
