### PR TITLE
feat(signal-slice): optimize subscription management

### DIFF
--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -1,3 +1,4 @@
+import { DestroyRef } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { Observable, Subject, of, timer } from 'rxjs';
@@ -242,6 +243,32 @@ describe(signalSlice.name, () => {
 				expect(state.increaseAgeUpdated()).toEqual(1);
 				state.increaseAge(1);
 				expect(state.increaseAgeUpdated()).toEqual(2);
+			});
+		});
+
+		it('should not register a new permanent subscription teardown on every call with a plain value', () => {
+			TestBed.runInInjectionContext(() => {
+				const destroyRef = TestBed.inject(DestroyRef);
+				const onDestroySpy = jest.spyOn(destroyRef, 'onDestroy');
+
+				const state = signalSlice({
+					initialState,
+					actionSources: {
+						increaseAge: (state, $: Observable<number>) =>
+							$.pipe(map((amount) => ({ age: state().age + amount }))),
+					},
+				});
+
+				// one permanent subscription is made at slice-creation time by
+				// the internal `connect(state, sharedObservable)` call
+				const baseline = onDestroySpy.mock.calls.length;
+				expect(baseline).toBeGreaterThan(0);
+
+				state.increaseAge(1);
+				state.increaseAge(1);
+				state.increaseAge(1);
+
+				expect(onDestroySpy.mock.calls.length).toEqual(baseline);
 			});
 		});
 

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -209,7 +209,6 @@ export function signalSlice<
 				destroyRef,
 				subject,
 				subs,
-				sharedObservable,
 			);
 		}
 	}
@@ -293,7 +292,6 @@ function addReducerProperties(
 	destroyRef: DestroyRef,
 	subject: Subject<unknown>,
 	subs: Subject<unknown>[],
-	observableFromActionSource?: Observable<any>,
 ) {
 	const version = createNotifier();
 	Object.defineProperties(readonlyState, {
@@ -317,12 +315,6 @@ function addReducerProperties(
 							},
 						});
 					});
-				}
-
-				if (observableFromActionSource) {
-					observableFromActionSource
-						.pipe(takeUntilDestroyed(destroyRef))
-						.subscribe();
 				}
 
 				return new Promise((res) => {


### PR DESCRIPTION
### Problem                                                                                                                                                                                          
                                                                                                                                                                                                       
  Calling a function-form `actionSource` (e.g. `increaseAge: (state, $) => $.pipe(...)`) with a plain, non-Observable value created a brand-new subscription to the action's already-connected, shared pipeline on **every call**, in addition to the one permanent subscription `connect()` makes once at slice-creation time. Each of these extra subscriptions was wired to `takeUntilDestroyed(destroyRef)` and only released when the owning injector was destroyed — never between calls — so live subscriptions accumulated without bound for the lifetime of the slice.     
                                                                                                                                                                                                       
  ### Root cause                                                                                                                                                                                       
                                                                                                                                                                                                       
  The offending `.subscribe()` call in `addReducerProperties` used to have real handlers: it fed an `effectTrigger` Subject that powered the experimental `actionEffects` API (added in #154). When `actionEffects` was removed in #361, the `next`/`error` handlers were stripped out but the bare `.subscribe()` call was left behind - a leftover with nothing listening, serving no purpose beyond registering a new teardown per call.                                                                                                                                                                 
                                                                                                                                                                                                       
  ### Fix                                                                                                                                                                                              
                                                                                                                                                                                                       
  Deleted the dead resubscription block and the now-unused `observableFromActionSource` parameter it depended on. State updates are unaffected - they were already handled entirely by the permanent `connect(state, sharedObservable)` subscription made once at slice creation.                                                                                                                         
                                                                                                                                                                                                       
  ### Testing                                                                                                                                                                                          
                                                                                                                                                                                                       
  - Added a regression test asserting that repeated calls to a plain-value action don't register additional `DestroyRef.onDestroy` teardowns beyond the one made at slice creation.                    
  - Verified the test fails against the old code (i.e. it actually catches the leak) and passes with the fix.                                                                                          
  - Full `signal-slice` suite (28 tests) and `ngxtension` lint pass.                                                                                                                                   
                                                                                                                                                                                                       
  No public API changes.   